### PR TITLE
Add `RSC` and `RSB` instructions.

### DIFF
--- a/ARM/arm.ml
+++ b/ARM/arm.ml
@@ -13,7 +13,7 @@ type reg_or_imm = Reg of register | Imm of int32
 
 type operand = Immediate of int32 | Register of register | ScaledRegister of register * reg_or_imm scale_type
 type register_offset = OImmediate of register * sign * int32 | ORegister of register * sign * register | OScaledRegister of register * sign * register * int32 scale_type
-type data_proc_instr = ADC | SBC | BIC | AND (* for JP: *) | ADD | SUB | ORR | EOR
+type data_proc_instr = ADC | SBC | RSC | BIC | AND (* for JP: *) | ADD | SUB | ORR | EOR | RSB
 type mov_instr = MOV | MVN
 type mem_instr = LDR | STR
 
@@ -282,12 +282,14 @@ let calculation_to_binary instr s cond rd rn op2 =
   let opcode = match instr with
   | ADC -> 0b0000_1010_0000_0000_0000_0000_0000
   | SBC -> 0b0000_1100_0000_0000_0000_0000_0000
+  | RSC -> 0b0000_1110_0000_0000_0000_0000_0000
   | BIC -> 0b0001_1100_0000_0000_0000_0000_0000
   | AND -> 0b0000_0000_0000_0000_0000_0000_0000
   | ADD -> 0b0000_1000_0000_0000_0000_0000_0000
   | SUB -> 0b0000_0100_0000_0000_0000_0000_0000
   | ORR -> 0b0001_1000_0000_0000_0000_0000_0000
   | EOR -> 0b0000_0010_0000_0000_0000_0000_0000
+  | RSB -> 0b0000_0110_0000_0000_0000_0000_0000
   in
   let scode = if s then 1 else 0 in
   let scode = shift_left (of_int scode) 20 in

--- a/ARM/arm.mli
+++ b/ARM/arm.mli
@@ -13,7 +13,7 @@ type reg_or_imm = Reg of register | Imm of int32
 
 type operand = Immediate of int32 | Register of register | ScaledRegister of register * reg_or_imm scale_type
 type register_offset = OImmediate of register * sign * int32 | ORegister of register * sign * register | OScaledRegister of register * sign * register * int32 scale_type
-type data_proc_instr = ADC | SBC | BIC | AND (* for JP: *) | ADD | SUB | ORR | EOR
+type data_proc_instr = ADC | SBC | RSC | BIC | AND (* for JP: *) | ADD | SUB | ORR | EOR | RSB
 type mov_instr = MOV | MVN
 type mem_instr = LDR | STR
 

--- a/ARM/arm_printer.ml
+++ b/ARM/arm_printer.ml
@@ -86,6 +86,7 @@ let data_proc_instr_to_str instr =
   match instr with
   | ADC -> "ADC" | SBC -> "SBC" | AND -> "AND" | BIC -> "BIC"
   | ADD -> "ADD" | SUB -> "SUB" | ORR -> "ORR" | EOR -> "EOR"
+  | RSC -> "RSC" | RSB -> "RSB"
 
 let pp_arm fmt arm =
   match arm with

--- a/ARM/parser_ast.ml
+++ b/ARM/parser_ast.ml
@@ -230,15 +230,17 @@ let asm_cmd3_to_arm env cmd args =
   | "LDR" -> Mem { instr=LDR ; typ ; cond ; rd=get_rd args ; ro=get_ro env args }
   | "STR" -> Mem { instr=STR ; typ ; cond ; rd=get_rd args ; ro=get_ro env args }
   | "MOV" -> Mov { instr=MOV ; s ; cond ; rd=get_rd args ; rs=get_rs env args }
-  | "MVN" -> Mov { instr=MVN; s ; cond ; rd=get_rd args ; rs=get_rs env args }
+  | "MVN" -> Mov { instr=MVN ; s ; cond ; rd=get_rd args ; rs=get_rs env args }
   | "ADC" -> DataProc { instr=ADC ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
   | "SBC" -> DataProc { instr=SBC ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
+  | "RSC" -> DataProc { instr=RSC ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
   | "BIC" -> DataProc { instr=BIC ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
   | "AND" -> DataProc { instr=AND ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
   | "ADD" -> DataProc { instr=ADD ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
   | "SUB" -> DataProc { instr=SUB ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
   | "ORR" -> DataProc { instr=ORR ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
   | "EOR" -> DataProc { instr=EOR ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
+  | "RSB" -> DataProc { instr=RSB ; s ; cond ; rd=get_rd args ; rn=get_rn args ; op2=get_op2 env args }
   | _ -> raise StructError
   with Failure _ | Invalid_argument _ -> raise StructError
 

--- a/html/doc/index.html
+++ b/html/doc/index.html
@@ -98,7 +98,7 @@
       <ul>
           <li>LDR (B/SB/H/SH/W/T/BT) and STR (B/H/W/T/BT)</li>
           <li>MOV and MVN</li>
-          <li>ADC, SBC, BIC and AND (the latter is writable only if the first operand is r0)</li>
+          <li>ADC, SBC, RSC, BIC and AND (the latter is writable only if the first operand is r0)</li>
           <li>B and BL</li>
       </ul>
 
@@ -118,7 +118,7 @@
 
       <p>The information above still applies to the Japanese version. However, as more characters are available in the Japanese version, some additional commands are available:</p>
       <ul>
-        <li>ADD, SUB, ORR and EOR</li>
+        <li>ADD, SUB, ORR, EOR and RSB</li>
         <li>BX and BLX</li>
       </ul>
 


### PR DESCRIPTION
With these instructions added, CodeGeneration now supports every writable Data Processing instruction for non-Japanese generation III games. Japanese still has the `TST`, `TEQ`, `CMP`, `CMN` but those require some special rules regarding encoding and printing.

`RSC` is actually writable with the non-Japanese character set but there are very few use cases for it in ACE codes so I am not surprised it got overlooked. It is basically this operation:

`Rd` = `<shifter_operand>` - `Rn` - (NOT CarryFlag)

`RSB` is Japanese only, but I included it in this PR mostly for completeness, it's `RSC` but without carry.

P.S: I don't really know OCaml. I just guessed how to add these instructions through searching for other instructions and seeing how they are implemented. I tested to make sure that this works, and doing the stuff I did in the commit seemed to make CodeGenerator recognise them as real ARM instructions.

P.S(2): I also kind of figured out how to disable the `BLX` instruction, since that instruction does not exist in the GBA's version of the ARM instruction set (ARMv4T). It does exist for the DS but I don't think this CodeGenerator is for the DS games so it does not make sense to support it. I did not add it to this pull request out of fear that the approach I used is too hacky, and that I feel that it is more important to get `RSC` supported and not dilute this PR too much with another feature.

**If the implementation in this PR is not up to standard, feel free to close this.**