### PR TITLE
Options menu, syntax highlighting, and UI polish for CodeGenerator

### DIFF
--- a/html/autocomplete.css
+++ b/html/autocomplete.css
@@ -1,62 +1,60 @@
-.container {
-    position: relative;
+:root {
+  --suggestion-bg: #fff;
+  --suggestion-border: rgb(203 213 225);
+  --suggestion-hover-bg: rgb(226 232 240);
 }
-.container > #main {
-    position: relative;
+
+html[data-theme="light"] {
+  --suggestion-bg: #fff;
+  --suggestion-border: rgb(203 213 225);
+  --suggestion-hover-bg: rgb(226 232 240);
 }
-.container__mirror {
-    position: absolute;
-    top: 0;
-    left: 0;
-    height: 100%;
-    width: 100%;
-    overflow: hidden;
-    color: transparent;
-}
-.container__suggestions {
-    border: 1px solid rgb(203 213 225);
-    background: #fff;
-    border-radius: 0.5rem;
-    display: none;
-    position: fixed;
-    width: 12rem;
-    overflow: auto;
-    max-height: 50%;
-}
-.container__suggestion {
-    align-items: center;
-    cursor: pointer;
-    display: flex;
-    height: 2rem;
-    padding: 0 0.5rem;
-}
-.container__suggestion:not(:first-child) {
-    border-top: 1px solid rgb(203 213 225);
-}
-.container__suggestion--focused {
-    background: rgb(226 232 240);
+
+html[data-theme="dark"] {
+  --suggestion-bg: #2a2a2a;
+  --suggestion-border: #555;
+  --suggestion-hover-bg: #3a3a3a;
 }
 
 @media (prefers-color-scheme: dark) {
-    html:not([data-theme="light"]) .container__suggestions {
-        background: #2a2a2a;
-        border-color: #555;
-    }
-    html:not([data-theme="light"]) .container__suggestion:not(:first-child) {
-        border-color: #555;
-    }
-    html:not([data-theme="light"]) .container__suggestion--focused {
-        background: #3a3a3a;
-    }
+  html:not([data-theme="light"]) {
+    --suggestion-bg: #2a2a2a;
+    --suggestion-border: #555;
+    --suggestion-hover-bg: #3a3a3a;
+  }
 }
 
-html[data-theme="dark"] .container__suggestions {
-    background: #2a2a2a;
-    border-color: #555;
+.container {
+  position: relative;
 }
-html[data-theme="dark"] .container__suggestion:not(:first-child) {
-    border-color: #555;
+
+.container__suggestions {
+  border: 1px solid var(--suggestion-border);
+  background: var(--suggestion-bg);
+  border-radius: var(--control-border-radius);
+  display: none;
+  position: fixed;
+  width: 12rem;
+  overflow: auto;
+  max-height: 50%;
+  z-index: 1000;
+  pointer-events: auto;
+  color: var(--body-text);
 }
-html[data-theme="dark"] .container__suggestion--focused {
-    background: #3a3a3a;
+
+.container__suggestion {
+  align-items: center;
+  cursor: pointer;
+  display: flex;
+  height: 2rem;
+  padding: 0 0.5rem;
+}
+
+.container__suggestion:not(:first-child) {
+  border-top: 1px solid var(--suggestion-border);
+}
+
+.container__suggestion--focused,
+.container__suggestion:hover {
+  background: var(--suggestion-hover-bg);
 }

--- a/html/autocomplete.js
+++ b/html/autocomplete.js
@@ -1,186 +1,270 @@
 // Credits to https://phuoc.ng/collection/mirror-a-text-area/add-autocomplete-to-your-text-area/
 
-document.addEventListener('DOMContentLoaded', () => {
-    const containerEle = document.getElementById('container');
-    const textarea = document.getElementById('main');
+document.addEventListener("DOMContentLoaded", () => {
+  const containerEle = document.getElementById("container");
+  const textarea = document.getElementById("main");
+  if (!containerEle || !textarea) return;
 
-    const mirroredEle = document.createElement('div');
-    mirroredEle.textContent = textarea.value;
-    mirroredEle.classList.add('container__mirror');
-    containerEle.prepend(mirroredEle);
+  const suggestionsEle = document.createElement("div");
+  suggestionsEle.classList.add("container__suggestions");
+  containerEle.appendChild(suggestionsEle);
 
-    const suggestionsEle = document.createElement('div');
-    suggestionsEle.classList.add('container__suggestions');
-    containerEle.appendChild(suggestionsEle);
+  let activeWordStart = 0;
+  let activeWordEnd = 0;
+  let currentSuggestionIndex = -1;
+  let suppressAutocomplete = false;
+
+  const clearFocusedSuggestions = () => {
+    suggestionsEle.querySelectorAll(".container__suggestion--focused").forEach((el) => {
+      el.classList.remove("container__suggestion--focused");
+    });
+  };
+
+  const getHighlightLayer = () => {
+    const editor = typeof Highlight !== "undefined" ? Highlight.getEditor("main") : null;
+    return editor ? editor.layer : null;
+  };
+
+  const hideSuggestions = () => {
+    suggestionsEle.style.display = "none";
+    currentSuggestionIndex = -1;
+  };
+
+  const findIndexesOfCurrentWord = () => {
+    const currentValue = textarea.value;
+    const cursorPos = textarea.selectionStart;
+
+    let startIndex = cursorPos - 1;
+    while (startIndex >= 0 && !/\s/.test(currentValue[startIndex])) {
+      startIndex--;
+    }
+    let endIndex = cursorPos;
+    while (endIndex < currentValue.length && !/\s/.test(currentValue[endIndex])) {
+      endIndex++;
+    }
+
+    return [startIndex + 1, endIndex];
+  };
+
+  const replaceCurrentWord = (newWord) => {
+    suppressAutocomplete = true;
+    const currentValue = textarea.value;
+    const startIndex = activeWordStart;
+    const endIndex = activeWordEnd;
+
+    const newValue = currentValue.substring(0, startIndex) + newWord + currentValue.substring(endIndex);
+    const scroll = textarea.scrollTop;
+    textarea.value = newValue;
+    textarea.focus();
+    textarea.selectionStart = textarea.selectionEnd = startIndex + newWord.length;
+    textarea.scrollTop = scroll;
+    hideSuggestions();
+    if (typeof Highlight !== "undefined") Highlight.refresh("main");
+    textarea.dispatchEvent(new Event("input", { bubbles: true }));
+  };
+
+  const positionSuggestions = (startIndex, endIndex) => {
+    const currentValue = textarea.value;
+    const currentWord = currentValue.substring(startIndex, endIndex);
+    const textBeforeWord = currentValue.substring(0, startIndex);
+    const textAfterWord = currentValue.substring(endIndex);
+
+    const layer = getHighlightLayer();
+    if (!layer) return null;
+
+    const mirror = document.createElement("div");
+    mirror.className = "autocomplete-mirror";
+    mirror.style.position = "absolute";
+    mirror.style.top = "0";
+    mirror.style.left = "0";
+    mirror.style.visibility = "hidden";
+    mirror.style.pointerEvents = "none";
+    mirror.style.whiteSpace = "pre-wrap";
+    mirror.style.wordWrap = "break-word";
 
     const textareaStyles = window.getComputedStyle(textarea);
     [
-        'border',
-        'boxSizing',
-        'fontFamily',
-        'fontSize',
-        'fontWeight',
-        'letterSpacing',
-        'textSizeAdjust',
-        'lineHeight',
-        'padding',
-        'textDecoration',
-        'textIndent',
-        'textTransform',
-        'whiteSpace',
-        'wordSpacing',
-        'wordWrap',
-    ].forEach((property) => {
-        mirroredEle.style[property] = textareaStyles[property];
-    });
-    mirroredEle.style.borderColor = 'transparent';
-
-    const parseValue = (v) => v.endsWith('px') ? parseInt(v.slice(0, -2), 10) : 0;
-    const borderWidth = parseValue(textareaStyles.borderWidth);
-
-    const ro = new ResizeObserver(() => {
-        mirroredEle.style.width = `${textarea.clientWidth + 2 * borderWidth}px`;
-        mirroredEle.style.height = `${textarea.clientHeight + 2 * borderWidth}px`;
-    });
-    ro.observe(textarea);
-
-    textarea.addEventListener('scroll', () => {
-        mirroredEle.scrollTop = textarea.scrollTop;
+      "boxSizing",
+      "borderTopWidth",
+      "borderRightWidth",
+      "borderBottomWidth",
+      "borderLeftWidth",
+      "fontFamily",
+      "fontSize",
+      "fontWeight",
+      "letterSpacing",
+      "lineHeight",
+      "paddingTop",
+      "paddingRight",
+      "paddingBottom",
+      "paddingLeft",
+      "tabSize",
+      "width",
+      "height",
+    ].forEach((prop) => {
+      mirror.style[prop] = textareaStyles[prop];
     });
 
-    const findIndexesOfCurrentWord = () => {
-        // Get current value and cursor position
-        const currentValue = textarea.value;
-        const cursorPos = textarea.selectionStart;
+    const pre = document.createTextNode(textBeforeWord);
+    const post = document.createTextNode(textAfterWord + (textAfterWord.endsWith("\n") ? " " : ""));
+    const caretEle = document.createElement("span");
+    caretEle.className = "autocomplete-caret";
+    caretEle.append(document.createTextNode(currentWord));
 
-        // Iterate backwards through characters until we find a space or newline character
-        let startIndex = cursorPos-1;
-        while (startIndex >= 0 && !/\s/.test(currentValue[startIndex])) {
-            startIndex--;
-        }
-        // Iterate forward through characters until we find a space or newline character
-        let endIndex = cursorPos;
-        while (endIndex < currentValue.length && !/\s/.test(currentValue[endIndex])) {
-            endIndex++;
-        }
-        
-        return [startIndex+1, endIndex];
-    };
+    mirror.append(pre, caretEle, post);
+    containerEle.appendChild(mirror);
+    mirror.scrollTop = textarea.scrollTop;
 
-    // Replace current word with selected suggestion
-    const replaceCurrentWord = (newWord) => {
-        const currentValue = textarea.value;
-        const [startIndex, endIndex] = findIndexesOfCurrentWord();
+    const rect = caretEle.getBoundingClientRect();
+    mirror.remove();
 
-        const newValue = currentValue.substring(0, startIndex) +
-                        newWord +
-                        currentValue.substring(endIndex);
-        const scroll = textarea.scrollTop;
-        textarea.value = newValue;
-        textarea.focus();
-        textarea.selectionStart = textarea.selectionEnd = startIndex + newWord.length;
-        textarea.scrollTop = scroll;
-    };
+    return rect;
+  };
 
-    ['input', 'selectionchange'].forEach(e =>
-        textarea.addEventListener(e, () => {
-            const currentValue = textarea.value;
-            const [startIndex, endIndex] = findIndexesOfCurrentWord();
-            if (endIndex <= startIndex) {
-                suggestionsEle.style.display = 'none';
-                return;
-            }
-    
-            const remaining = currentValue.substring(endIndex);
-            const lineBreak = remaining.indexOf("\n");
-            const lineEnd = lineBreak >= 0 ? remaining.substring(0, lineBreak) : remaining;
-            const tags = lineEnd.match(/@input:\w*/g)
-            if (tags === null) {
-                suggestionsEle.style.display = 'none';
-                return;
-            }
-            const groups = tags.map(x => x.substring(7));
-            const suggestions = groups.map((x) => pkmn_data[x]).filter((x) => x !== undefined).flat(1);
-    
-            // Extract just the current word
-            const currentWord = currentValue.substring(startIndex, endIndex);
-            if (currentWord === '') {
-                suggestionsEle.style.display = 'none';
-                return;
-            }
-    
-            const matches = suggestions.filter((suggestion) =>
-                suggestion.toLowerCase().startsWith(currentWord.toLowerCase()) || parseInt(currentWord) === pkmn_data_map[suggestion]);
-            if (matches.length === 0) {
-                suggestionsEle.style.display = 'none';
-                return;
-            }
-    
-            const textBeforeWord = currentValue.substring(0, startIndex);
-            const textAfterWord = currentValue.substring(endIndex);
-    
-            const pre = document.createTextNode(textBeforeWord);
-            const post = document.createTextNode(textAfterWord + (textAfterWord.endsWith("\n") ? " " : ""));
-            const caretEle = document.createElement('span');
-            caretEle.innerHTML = '';
-            caretEle.append(document.createTextNode(currentWord));
-    
-            mirroredEle.innerHTML = '';
-            mirroredEle.append(pre, caretEle, post);
-            mirroredEle.scrollTop = textarea.scrollTop;
-    
-            const rect = caretEle.getBoundingClientRect();
-            suggestionsEle.style.top = `${rect.top + rect.height}px`;
-            suggestionsEle.style.left = `${rect.left}px`;
-    
-            suggestionsEle.innerHTML = '';
-            matches.forEach((match) => {
-                const option = document.createElement('div');
-                option.innerText = match;
-                option.classList.add('container__suggestion');
-                option.addEventListener('click', function() {
-                    replaceCurrentWord(pkmn_data_map[this.innerText].toString());
-                    suggestionsEle.style.display = 'none';
-                });
-                suggestionsEle.appendChild(option);
-            });
-            suggestionsEle.style.display = 'block';
-        })
-    );
+  const showSuggestions = (matches, startIndex, endIndex) => {
+    activeWordStart = startIndex;
+    activeWordEnd = endIndex;
+    currentSuggestionIndex = -1;
 
-    const clamp = (min, value, max) => Math.min(Math.max(min, value), max);
+    const rect = positionSuggestions(startIndex, endIndex);
+    if (!rect) {
+      hideSuggestions();
+      return;
+    }
 
-    let currentSuggestionIndex = -1;
-    textarea.addEventListener('keydown', (e) => {
-        if (!['Enter', 'Escape', 'Tab'].includes(e.key)) {
-            return;
-        }
+    suggestionsEle.style.top = `${rect.top + rect.height}px`;
+    suggestionsEle.style.left = `${rect.left}px`;
 
-        const suggestions = suggestionsEle.querySelectorAll('.container__suggestion');
-        const numSuggestions = suggestions.length;
-        if (numSuggestions === 0 || suggestionsEle.style.display === 'none') {
-            return;
-        }
+    suggestionsEle.innerHTML = "";
+    suggestionsEle.scrollTop = 0;
+    matches.forEach((match, index) => {
+      const option = document.createElement("div");
+      option.innerText = match;
+      option.classList.add("container__suggestion");
+      option.addEventListener("mouseenter", () => {
+        clearFocusedSuggestions();
+        option.classList.add("container__suggestion--focused");
+        currentSuggestionIndex = index;
+      });
+      option.addEventListener("mouseleave", () => {
+        option.classList.remove("container__suggestion--focused");
+        currentSuggestionIndex = -1;
+      });
+      option.addEventListener("mousedown", (e) => {
         e.preventDefault();
-        switch (e.key) {
-            case 'Tab':
-                suggestions[
-                    clamp(0, currentSuggestionIndex, numSuggestions - 1)
-                ].classList.remove('container__suggestion--focused');
-                currentSuggestionIndex = clamp(0, currentSuggestionIndex + 1, numSuggestions) % numSuggestions;
-                suggestions[currentSuggestionIndex].classList.add('container__suggestion--focused');
-                break;
-            case 'Enter':
-                replaceCurrentWord(pkmn_data_map[suggestions[currentSuggestionIndex].innerText].toString());
-                currentSuggestionIndex = -1;
-                suggestionsEle.style.display = 'none';
-                break;
-            case 'Escape':
-                currentSuggestionIndex = -1;
-                suggestionsEle.style.display = 'none';
-                break;
-            default:
-                break;
-        }
+        e.stopPropagation();
+        replaceCurrentWord(pkmn_data_map[match].toString());
+      });
+      suggestionsEle.appendChild(option);
     });
+    suggestionsEle.style.display = "block";
+  };
+
+  const updateSuggestions = () => {
+    if (suppressAutocomplete) {
+      hideSuggestions();
+      return;
+    }
+
+    const currentValue = textarea.value;
+    const [startIndex, endIndex] = findIndexesOfCurrentWord();
+    if (endIndex <= startIndex) {
+      hideSuggestions();
+      return;
+    }
+
+    const remaining = currentValue.substring(endIndex);
+    const lineBreak = remaining.indexOf("\n");
+    const lineEnd = lineBreak >= 0 ? remaining.substring(0, lineBreak) : remaining;
+    const tags = lineEnd.match(/@input:\w*/g);
+    if (tags === null) {
+      hideSuggestions();
+      return;
+    }
+    const groups = tags.map((x) => x.substring(7));
+    const suggestions = groups
+      .map((x) => pkmn_data[x])
+      .filter((x) => x !== undefined)
+      .flat(1);
+
+    const currentWord = currentValue.substring(startIndex, endIndex);
+    if (currentWord === "") {
+      hideSuggestions();
+      return;
+    }
+
+    const matches = FuzzySearch.filterAndRank(
+      suggestions,
+      currentWord,
+      (suggestion) => suggestion,
+      (suggestion) => pkmn_data_map[suggestion],
+    );
+    if (matches.length === 0) {
+      hideSuggestions();
+      return;
+    }
+
+    showSuggestions(matches, startIndex, endIndex);
+  };
+
+  ["input", "selectionchange"].forEach((e) => textarea.addEventListener(e, updateSuggestions));
+
+  textarea.addEventListener("keydown", () => {
+    suppressAutocomplete = false;
+  });
+
+  const scrollSuggestionIntoView = (option) => {
+    const viewTop = suggestionsEle.scrollTop;
+    const viewBottom = viewTop + suggestionsEle.clientHeight;
+    const optionTop = option.offsetTop;
+    const optionBottom = optionTop + option.offsetHeight;
+
+    if (optionTop < viewTop) {
+      suggestionsEle.scrollTop = optionTop;
+    } else if (optionBottom > viewBottom) {
+      suggestionsEle.scrollTop = optionBottom - suggestionsEle.clientHeight;
+    }
+  };
+
+  const focusSuggestionAt = (index) => {
+    const suggestions = suggestionsEle.querySelectorAll(".container__suggestion");
+    if (suggestions.length === 0) return;
+
+    clearFocusedSuggestions();
+    currentSuggestionIndex = index;
+    const option = suggestions[currentSuggestionIndex];
+    option.classList.add("container__suggestion--focused");
+    scrollSuggestionIntoView(option);
+  };
+
+  textarea.addEventListener("keydown", (e) => {
+    if (!["Enter", "Escape", "Tab"].includes(e.key)) {
+      return;
+    }
+
+    const suggestions = suggestionsEle.querySelectorAll(".container__suggestion");
+    const numSuggestions = suggestions.length;
+    if (numSuggestions === 0 || suggestionsEle.style.display === "none") {
+      return;
+    }
+    e.preventDefault();
+    switch (e.key) {
+      case "Tab":
+        if (e.shiftKey) {
+          focusSuggestionAt(currentSuggestionIndex <= 0 ? numSuggestions - 1 : currentSuggestionIndex - 1);
+        } else {
+          focusSuggestionAt((currentSuggestionIndex + 1) % numSuggestions);
+        }
+        break;
+      case "Enter":
+        const pickIndex = currentSuggestionIndex >= 0 ? currentSuggestionIndex : 0;
+        replaceCurrentWord(pkmn_data_map[suggestions[pickIndex].innerText].toString());
+        break;
+      case "Escape":
+        hideSuggestions();
+        break;
+      default:
+        break;
+    }
+  });
 });

--- a/html/config.js
+++ b/html/config.js
@@ -1,1 +1,1 @@
-let repository = "https://e-sh4rk.github.io/EmeraldACE_web/"
+let repository = "https://e-sh4rk.github.io/EmeraldACE_web/";

--- a/html/fuzzysearch.js
+++ b/html/fuzzysearch.js
@@ -1,7 +1,13 @@
 const FuzzySearch = (function () {
-  function normalize(s) {
+  function foldDiacritics(s) {
     return s
       .toLowerCase()
+      .normalize("NFD")
+      .replace(/[\u0300-\u036f]/g, "");
+  }
+
+  function normalize(s) {
+    return foldDiacritics(s)
       .replace(/_/g, " ")
       .replace(/[^\w\s]/g, "")
       .replace(/\s+/g, " ")
@@ -15,10 +21,10 @@ const FuzzySearch = (function () {
   function score(query, text, id) {
     if (!query) return 0;
 
-    const q = query.toLowerCase();
+    const q = foldDiacritics(query);
     const qNorm = normalize(query);
     const qCompact = compact(query);
-    const tLower = text.toLowerCase();
+    const tLower = foldDiacritics(text);
     const tNorm = normalize(text);
     const tCompact = compact(text);
 

--- a/html/fuzzysearch.js
+++ b/html/fuzzysearch.js
@@ -1,0 +1,90 @@
+const FuzzySearch = (function () {
+  function normalize(s) {
+    return s
+      .toLowerCase()
+      .replace(/_/g, " ")
+      .replace(/[^\w\s]/g, "")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  function compact(s) {
+    return normalize(s).replace(/\s/g, "");
+  }
+
+  function score(query, text, id) {
+    if (!query) return 0;
+
+    const q = query.toLowerCase();
+    const qNorm = normalize(query);
+    const qCompact = compact(query);
+    const tLower = text.toLowerCase();
+    const tNorm = normalize(text);
+    const tCompact = compact(text);
+
+    if (id !== undefined && /^\d+$/.test(q)) {
+      const num = parseInt(q, 10);
+      if (num === id) return 1000;
+      if (String(id).startsWith(q)) return 500 + q.length;
+    }
+
+    if (tLower === q) return 900;
+    if (tNorm === qNorm) return 850;
+
+    if (tLower.startsWith(q)) return 800;
+    if (tNorm.startsWith(qNorm)) return 750;
+    if (tCompact.startsWith(qCompact)) return 700;
+
+    if (tLower.includes(q)) return 600;
+    if (tNorm.includes(qNorm)) return 550;
+    if (tCompact.includes(qCompact)) return 500;
+
+    const qWords = qNorm.split(" ").filter(Boolean);
+    const tWords = tNorm.split(" ").filter(Boolean);
+    if (qWords.length > 1) {
+      let wordScore = 0;
+      let matched = 0;
+      for (let i = 0; i < qWords.length; i++) {
+        const qw = qWords[i];
+        const tw = tWords[i];
+        if (tw && tw.startsWith(qw)) {
+          matched++;
+          wordScore += 80;
+        }
+      }
+      if (matched === qWords.length) return 400 + wordScore;
+    }
+
+    let qi = 0;
+    for (let i = 0; i < tCompact.length && qi < qCompact.length; i++) {
+      if (tCompact[i] === qCompact[qi]) qi++;
+    }
+    if (qi === qCompact.length && qCompact.length > 0) {
+      return 100 + (qCompact.length / tCompact.length) * 200;
+    }
+
+    return 0;
+  }
+
+  function filterAndRank(items, query, getText, getId, limit = 50) {
+    if (!query) return [];
+
+    const results = [];
+    for (const item of items) {
+      const text = getText(item);
+      const id = getId ? getId(item) : undefined;
+      const s = score(query, text, id);
+      if (s > 0) results.push({ item, score: s, text });
+    }
+
+    results.sort((a, b) => b.score - a.score || a.text.length - b.text.length);
+    return results.slice(0, limit).map((r) => r.item);
+  }
+
+  function tomSelectScore(search, text) {
+    if (!search || !search.trim()) return 1;
+    return score(search, text);
+  }
+
+  return { normalize, score, filterAndRank, tomSelectScore };
+})();

--- a/html/highlight.js
+++ b/html/highlight.js
@@ -1,0 +1,225 @@
+const Highlight = (() => {
+  const editors = new Map();
+
+  const MIRROR_PROPS = [
+    "boxSizing",
+    "borderTopWidth",
+    "borderRightWidth",
+    "borderBottomWidth",
+    "borderLeftWidth",
+    "borderStyle",
+    "borderRadius",
+    "fontFamily",
+    "fontSize",
+    "fontWeight",
+    "fontStyle",
+    "letterSpacing",
+    "textSizeAdjust",
+    "lineHeight",
+    "paddingTop",
+    "paddingRight",
+    "paddingBottom",
+    "paddingLeft",
+    "textDecoration",
+    "textIndent",
+    "textTransform",
+    "wordSpacing",
+    "tabSize",
+  ];
+
+  function escapeHtml(text) {
+    return text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+  }
+
+  function charClass(ch) {
+    if (/[0-9]/.test(ch)) return "number";
+    if (/[A-Za-z]/.test(ch) || /[\u3040-\u30ff\u4e00-\u9fff]/.test(ch)) return "letter";
+    if (/\s/.test(ch)) return "space";
+    return "symbol";
+  }
+
+  function wrapChar(ch, cls, inBracket) {
+    if (ch === " " || ch === "\t") return ch;
+    const settings = Options.load();
+    const box = settings.boxNames;
+    let type = cls;
+    if (type === "auto") type = charClass(ch);
+    let styleClass = "hl-box-" + type;
+    if (inBracket && type !== "space") styleClass = "hl-box-bracket-inner hl-box-" + type;
+    let weight = "";
+    if (type === "number" && box.numberBold) weight = " hl-box-bold";
+    if (type === "symbol" && box.symbolBold) weight = " hl-box-bold";
+    return `<span class="${styleClass}${weight}">${escapeHtml(ch)}</span>`;
+  }
+
+  function highlightBoxNameLine(line) {
+    const match = line.match(/^(Box\s+)(\d+)(:\s+)(.+?)(\s+\[)(.+)(\])$/);
+    if (!match) return escapeHtml(line);
+
+    const settings = Options.load();
+    if (!settings.boxNames.enabled) return escapeHtml(line);
+
+    let html = `<span class="hl-box-label">${escapeHtml(match[1])}</span>`;
+    html += `<span class="hl-box-label">${escapeHtml(match[2])}</span>`;
+    html += `<span class="hl-box-label">${escapeHtml(match[3])}</span>`;
+
+    for (const ch of match[4]) {
+      html += wrapChar(ch, "auto", false);
+    }
+
+    html += `<span class="hl-box-bracket">${escapeHtml(match[5])}</span>`;
+    for (const ch of match[6]) {
+      html += wrapChar(ch, "auto", true);
+    }
+    html += `<span class="hl-box-bracket">${escapeHtml(match[7])}</span>`;
+    return html;
+  }
+
+  function highlightCodeLine(line) {
+    const settings = Options.load();
+    if (!settings.comments.enabled) return escapeHtml(line);
+
+    const trimmed = line.trimStart();
+    const leading = line.slice(0, line.length - trimmed.length);
+
+    if (trimmed.startsWith("@@")) {
+      return escapeHtml(leading) + `<span class="hl-comment-header">${escapeHtml(trimmed)}</span>`;
+    }
+    if (trimmed.startsWith("//")) {
+      return escapeHtml(leading) + `<span class="hl-comment-slash">${escapeHtml(trimmed)}</span>`;
+    }
+    if (trimmed.startsWith(";")) {
+      return escapeHtml(leading) + `<span class="hl-comment-semicolon">${escapeHtml(trimmed)}</span>`;
+    }
+    if (trimmed.startsWith("%%")) {
+      return escapeHtml(leading) + `<span class="hl-comment-percent">${escapeHtml(trimmed)}</span>`;
+    }
+
+    const commentIdx = line.indexOf(";");
+    if (commentIdx >= 0 && !line.trimStart().startsWith("0x")) {
+      const code = line.slice(0, commentIdx);
+      const comment = line.slice(commentIdx);
+      if (comment.match(/^;\s*\((altered|filler)\)/) || comment.includes("EXIT CODE")) {
+        return escapeHtml(code) + `<span class="hl-comment-semicolon">${escapeHtml(comment)}</span>`;
+      }
+    }
+
+    return escapeHtml(line);
+  }
+
+  function highlightText(text, mode) {
+    const lines = text.split("\n");
+    return lines
+      .map((line) => {
+        if (mode === "output") {
+          if (/^Box\s+\d+:/.test(line)) return highlightBoxNameLine(line);
+          return highlightCodeLine(line);
+        }
+        return highlightCodeLine(line);
+      })
+      .join("\n");
+  }
+
+  function copyTextareaStyles(textarea, layer) {
+    const styles = window.getComputedStyle(textarea);
+    MIRROR_PROPS.forEach((prop) => {
+      layer.style[prop] = styles[prop];
+    });
+    layer.style.borderColor = "transparent";
+    layer.style.overflow = "hidden";
+  }
+
+  function createEditor(textarea, mode) {
+    const wrap = textarea.closest(".editor-wrap, .container");
+    if (!wrap) return null;
+
+    wrap.classList.add("editor-wrap");
+
+    let layer = wrap.querySelector(".highlight-layer");
+    if (!layer) {
+      layer = document.createElement("div");
+      layer.className = "highlight-layer";
+      layer.setAttribute("aria-hidden", "true");
+      wrap.insertBefore(layer, textarea);
+    }
+
+    const syncStyles = () => copyTextareaStyles(textarea, layer);
+
+    const update = () => {
+      syncStyles();
+      const settings = Options.load();
+      const commentsOn = settings.comments.enabled;
+      const boxOn = settings.boxNames.enabled && mode === "output";
+      const active = mode === "output" ? commentsOn || boxOn : commentsOn;
+
+      textarea.classList.toggle("editor--highlighted", active);
+      if (!active) {
+        layer.innerHTML = "";
+        return;
+      }
+
+      const value = textarea.value;
+      let html = highlightText(value, mode);
+      if (value.endsWith("\n")) html += "\n";
+      layer.innerHTML = html;
+      layer.scrollTop = textarea.scrollTop;
+      layer.scrollLeft = textarea.scrollLeft;
+    };
+
+    const ro = new ResizeObserver(() => {
+      syncStyles();
+      update();
+    });
+    ro.observe(wrap);
+    ro.observe(textarea);
+    syncStyles();
+
+    textarea.addEventListener("input", update);
+    textarea.addEventListener("scroll", () => {
+      layer.scrollTop = textarea.scrollTop;
+      layer.scrollLeft = textarea.scrollLeft;
+    });
+
+    const editor = { textarea, layer, mode, update, syncStyles };
+    editors.set(textarea.id, editor);
+    update();
+    requestAnimationFrame(update);
+    return editor;
+  }
+
+  function getEditor(textareaId) {
+    return editors.get(textareaId) || null;
+  }
+
+  function refreshAll() {
+    for (const editor of editors.values()) {
+      editor.update();
+    }
+  }
+
+  function refresh(textareaId) {
+    const editor = editors.get(textareaId);
+    if (editor) editor.update();
+  }
+
+  function init() {
+    const main = document.getElementById("main");
+    const secondary = document.getElementById("secondary");
+    const output = document.getElementById("output");
+    if (main) createEditor(main, "code");
+    if (secondary) createEditor(secondary, "code");
+    if (output) createEditor(output, "output");
+  }
+
+  window.addEventListener("DOMContentLoaded", init);
+
+  return {
+    createEditor,
+    getEditor,
+    refreshAll,
+    refresh,
+    highlightText,
+    escapeHtml,
+    copyTextareaStyles,
+  };
+})();

--- a/html/index.html
+++ b/html/index.html
@@ -1,27 +1,33 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pokemon Emerald 0x611 ACE generator</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="autocomplete.css">
-    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="options.css" />
+    <link rel="stylesheet" href="autocomplete.css" />
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.min.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/js/tom-select.complete.min.js"></script>
     <script src="ace_js.bc.js?2"></script>
     <script src="config.js"></script>
+    <script src="fuzzysearch.js"></script>
+    <script src="options.js"></script>
     <script src="scripts.js"></script>
+    <script src="highlight.js"></script>
     <script src="ids.js"></script>
     <script src="autocomplete.js"></script>
   </head>
   <body>
-    <input type="hidden" id="script_workspace" value="files">
+    <input type="hidden" id="script_workspace" value="files" />
     <div class="row">
       <div id="mainTab" class="column grow tabcontent-active">
-        <h2><a class="tablinks-active">Main code</a> /
-            <a class="tablinks" onclick="openTab(event,'secondaryTab');">Exit codes</a>
-            (<a href="doc/index.html">documentation</a>)</h2>
-        
+        <h2>
+          <a class="tablinks-active">Main code</a> /
+          <a class="tablinks" onclick="openTab(event, 'secondaryTab')">Exit codes</a>
+          (<a href="doc/index.html">documentation</a>)
+        </h2>
+
         <div class="row">
           <select id="lang" class="left">
             <option value="eng">English</option>
@@ -32,7 +38,7 @@
             <option value="jap">Japanese</option>
             <option value="abc">Hexadecimal</option>
           </select>
-          <select style="display:none;" id="game" class="middle">
+          <select style="display: none" id="game" class="middle">
             <option value="">All games</option>
           </select>
           <select id="cat" class="middle">
@@ -44,7 +50,7 @@
           </select>
           <select id="select" class="right grow"></select>
         </div>
-        <div class="container grow" id="container">
+        <div class="container grow editor-wrap" id="container">
           <textarea id="main" spellcheck="false"></textarea>
         </div>
         <div class="row">
@@ -54,21 +60,91 @@
       </div>
 
       <div id="secondaryTab" class="column grow tabcontent">
-        <h2><a class="tablinks" onclick="openTab(event,'mainTab');">Main code</a> /
-            <a class="tablinks-active">Exit codes</a>
-            (<a href="doc/index.html">documentation</a>)</h2>
+        <h2>
+          <a class="tablinks" onclick="openTab(event, 'mainTab')">Main code</a> /
+          <a class="tablinks-active">Exit codes</a>
+          (<a href="doc/index.html">documentation</a>)
+        </h2>
 
-        <textarea id="secondary" class="grow" spellcheck="false"></textarea>
+        <div class="editor-wrap grow">
+          <textarea id="secondary" spellcheck="false"></textarea>
+        </div>
       </div>
-      
+
       <div class="column grow">
         <h2>Result</h2>
-        <textarea id="output" class="grow" spellcheck="false" readonly></textarea>
+        <div class="editor-wrap grow">
+          <textarea id="output" spellcheck="false" readonly></textarea>
+        </div>
       </div>
     </div>
-    <p><button id="theme-toggle" onclick="toggleTheme()" type="button">Dark mode</button></p>
-    <p>Generator for <a href="index.html">Emerald</a> / <a href="index_frlg.html">FRLG</a> / <a href="index_rs.html">RS</a>&nbsp;&nbsp;-&nbsp;&nbsp;<a href="https://github.com/E-Sh4rk/CodeGeneratorOffline">Offline version</a></p>
-    <p>Emerald ACE tutorials: <a href="https://e-sh4rk.github.io/ACE3/emerald/getting-started/introduction/">Articles by E-Sh4rk</a> - <a href="https://youtu.be/45kwOEhKbUg">Video by Papa Jefé</a></p>
-    <p>Useful links: <a href="https://pastebin.com/u/Sleipnir17">Sleipnir's Pastebin</a> (plenty of ACE codes) - <a href="https://www.youtube.com/@PapaJefeYT/videos">Papa Jefé's Youtube</a> (ACE tutorials) - <a href="https://github.com/E-Sh4rk/PokeGlitzer">PokeGlitzer</a> (save editor for glitchers)</p>
+    <p><button id="options-button" type="button">Options</button></p>
+    <p>
+      Generator for <a href="index.html">Emerald</a> / <a href="index_frlg.html">FRLG</a> /
+      <a href="index_rs.html">RS</a>&nbsp;&nbsp;-&nbsp;&nbsp;<a href="https://github.com/E-Sh4rk/CodeGeneratorOffline"
+        >Offline version</a
+      >
+    </p>
+    <p>
+      Emerald ACE tutorials:
+      <a href="https://e-sh4rk.github.io/ACE3/emerald/getting-started/introduction/">Articles by E-Sh4rk</a> -
+      <a href="https://youtu.be/45kwOEhKbUg">Video by Papa Jefé</a>
+    </p>
+    <p>
+      Useful links: <a href="https://pastebin.com/u/Sleipnir17">Sleipnir's Pastebin</a> (plenty of ACE codes) -
+      <a href="https://www.youtube.com/@PapaJefeYT/videos">Papa Jefé's Youtube</a> (ACE tutorials) -
+      <a href="https://github.com/E-Sh4rk/PokeGlitzer">PokeGlitzer</a> (save editor for glitchers)
+    </p>
+
+    <div id="options-modal" class="options-modal" role="dialog" aria-labelledby="options-title" aria-hidden="true">
+      <div class="options-modal__backdrop"></div>
+      <div class="options-modal__panel">
+        <div class="options-modal__header">
+          <h3 id="options-title">Options</h3>
+          <button type="button" class="options-modal__close" aria-label="Close">×</button>
+        </div>
+        <section class="options-section">
+          <h4>Theme</h4>
+          <div class="options-radio-group">
+            <label><input type="radio" name="theme" value="system" /> System</label>
+            <label><input type="radio" name="theme" value="light" /> Light</label>
+            <label><input type="radio" name="theme" value="dark" /> Dark</label>
+          </div>
+        </section>
+        <section class="options-section">
+          <h4>Default options (this page)</h4>
+          <div class="options-row">
+            <label for="options-default-lang">Language</label>
+            <select id="options-default-lang"></select>
+          </div>
+          <div class="options-row" id="options-default-game-row">
+            <label for="options-default-game">Game</label>
+            <select id="options-default-game"></select>
+          </div>
+          <div class="options-actions">
+            <button type="button" id="options-use-current">Use current selection</button>
+            <button type="button" id="options-save-defaults">Save as default for this page</button>
+          </div>
+        </section>
+        <section class="options-section">
+          <h4>Comment colors</h4>
+          <div class="options-row">
+            <label><input type="checkbox" id="options-comments-enabled" /> Enable comment highlighting</label>
+          </div>
+          <div id="options-comment-color-fields"></div>
+        </section>
+        <section class="options-section">
+          <h4>Box name styling (output)</h4>
+          <div class="options-row">
+            <label><input type="checkbox" id="options-boxnames-enabled" /> Enable box name styling</label>
+          </div>
+          <div class="options-row">
+            <label><input type="checkbox" id="options-box-number-bold" /> Bold numbers</label>
+            <label><input type="checkbox" id="options-box-symbol-bold" /> Bold symbols</label>
+          </div>
+          <div id="options-box-color-fields"></div>
+        </section>
+      </div>
+    </div>
   </body>
 </html>

--- a/html/index_frlg.html
+++ b/html/index_frlg.html
@@ -1,27 +1,33 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pokemon FRLG ACE generator</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="autocomplete.css">
-    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="options.css" />
+    <link rel="stylesheet" href="autocomplete.css" />
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.min.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/js/tom-select.complete.min.js"></script>
     <script src="ace_js.bc.js?2"></script>
     <script src="config.js"></script>
+    <script src="fuzzysearch.js"></script>
+    <script src="options.js"></script>
     <script src="scripts.js"></script>
+    <script src="highlight.js"></script>
     <script src="ids.js"></script>
     <script src="autocomplete.js"></script>
-</head>
+  </head>
   <body>
-    <input type="hidden" id="script_workspace" value="files_frlg">
+    <input type="hidden" id="script_workspace" value="files_frlg" />
     <div class="row">
       <div id="mainTab" class="column grow tabcontent-active">
-        <h2><a class="tablinks-active">Main code</a> /
-            <a class="tablinks" onclick="openTab(event,'secondaryTab');">Exit codes</a>
-            (<a href="doc/index.html">documentation</a>)</h2>
-        
+        <h2>
+          <a class="tablinks-active">Main code</a> /
+          <a class="tablinks" onclick="openTab(event, 'secondaryTab')">Exit codes</a>
+          (<a href="doc/index.html">documentation</a>)
+        </h2>
+
         <div class="row">
           <select id="lang" class="left">
             <option value="eng1">English 1.1</option>
@@ -43,12 +49,12 @@
             <option value="fr">Fire-Red</option>
             <option value="lg">Leaf-Green</option>
           </select>
-          <select style="display:none;" id="cat" class="middle">
+          <select style="display: none" id="cat" class="middle">
             <option value="">All categories</option>
           </select>
           <select id="select" class="right grow"></select>
         </div>
-        <div class="container grow" id="container">
+        <div class="container grow editor-wrap" id="container">
           <textarea id="main" spellcheck="false"></textarea>
         </div>
         <div class="row">
@@ -58,22 +64,94 @@
       </div>
 
       <div id="secondaryTab" class="column grow tabcontent">
-        <h2><a class="tablinks" onclick="openTab(event,'mainTab');">Main code</a> /
-            <a class="tablinks-active">Exit codes</a>
-            (<a href="doc/index.html">documentation</a>)</h2>
+        <h2>
+          <a class="tablinks" onclick="openTab(event, 'mainTab')">Main code</a> /
+          <a class="tablinks-active">Exit codes</a>
+          (<a href="doc/index.html">documentation</a>)
+        </h2>
 
-        <textarea id="secondary" class="grow" spellcheck="false"></textarea>
+        <div class="editor-wrap grow">
+          <textarea id="secondary" spellcheck="false"></textarea>
+        </div>
       </div>
-      
+
       <div class="column grow">
         <h2>Result</h2>
-        <textarea id="output" class="grow" spellcheck="false" readonly></textarea>
+        <div class="editor-wrap grow">
+          <textarea id="output" spellcheck="false" readonly></textarea>
+        </div>
       </div>
     </div>
-    <p><button id="theme-toggle" onclick="toggleTheme()" type="button">Dark mode</button></p>
-    <p>Generator for <a href="index.html">Emerald</a> / <a href="index_frlg.html">FRLG</a> / <a href="index_rs.html">RS</a>&nbsp;&nbsp;-&nbsp;&nbsp;<a href="https://github.com/E-Sh4rk/CodeGeneratorOffline">Offline version</a></p>
-    <p>FRLG ACE tutorials: <a href="https://youtu.be/v_JfJ0WS07U">Video by Papa Jefé</a> - <a href="https://pomeg-letterbombers.github.io/pokemon-ace-notes/">Written guide</a> - <a href="https://e-sh4rk.github.io/EmeraldACE_web/doc/FRLG_Short_Exit_Codes_Guide.pdf">Short exit code guide by Sleipnir17</a></p>
+    <p><button id="options-button" type="button">Options</button></p>
+    <p>
+      Generator for <a href="index.html">Emerald</a> / <a href="index_frlg.html">FRLG</a> /
+      <a href="index_rs.html">RS</a>&nbsp;&nbsp;-&nbsp;&nbsp;<a href="https://github.com/E-Sh4rk/CodeGeneratorOffline"
+        >Offline version</a
+      >
+    </p>
+    <p>
+      FRLG ACE tutorials: <a href="https://youtu.be/v_JfJ0WS07U">Video by Papa Jefé</a> -
+      <a href="https://pomeg-letterbombers.github.io/pokemon-ace-notes/">Written guide</a> -
+      <a href="https://e-sh4rk.github.io/EmeraldACE_web/doc/FRLG_Short_Exit_Codes_Guide.pdf"
+        >Short exit code guide by Sleipnir17</a
+      >
+    </p>
     <p>Note: Codes are for Grab ACE by default (unless specified otherwise in the title).</p>
-    <p>Useful links: <a href="https://pastebin.com/u/Sleipnir17">Sleipnir's Pastebin</a> (plenty of ACE codes) - <a href="https://www.youtube.com/@PapaJefeYT/videos">Papa Jefé's Youtube</a> (ACE tutorials) - <a href="https://github.com/E-Sh4rk/PokeGlitzer">PokeGlitzer</a> (save editor for glitchers)</p>
+    <p>
+      Useful links: <a href="https://pastebin.com/u/Sleipnir17">Sleipnir's Pastebin</a> (plenty of ACE codes) -
+      <a href="https://www.youtube.com/@PapaJefeYT/videos">Papa Jefé's Youtube</a> (ACE tutorials) -
+      <a href="https://github.com/E-Sh4rk/PokeGlitzer">PokeGlitzer</a> (save editor for glitchers)
+    </p>
+
+    <div id="options-modal" class="options-modal" role="dialog" aria-labelledby="options-title" aria-hidden="true">
+      <div class="options-modal__backdrop"></div>
+      <div class="options-modal__panel">
+        <div class="options-modal__header">
+          <h3 id="options-title">Options</h3>
+          <button type="button" class="options-modal__close" aria-label="Close">×</button>
+        </div>
+        <section class="options-section">
+          <h4>Theme</h4>
+          <div class="options-radio-group">
+            <label><input type="radio" name="theme" value="system" /> System</label>
+            <label><input type="radio" name="theme" value="light" /> Light</label>
+            <label><input type="radio" name="theme" value="dark" /> Dark</label>
+          </div>
+        </section>
+        <section class="options-section">
+          <h4>Default options (this page)</h4>
+          <div class="options-row">
+            <label for="options-default-lang">Language</label>
+            <select id="options-default-lang"></select>
+          </div>
+          <div class="options-row" id="options-default-game-row">
+            <label for="options-default-game">Game</label>
+            <select id="options-default-game"></select>
+          </div>
+          <div class="options-actions">
+            <button type="button" id="options-use-current">Use current selection</button>
+            <button type="button" id="options-save-defaults">Save as default for this page</button>
+          </div>
+        </section>
+        <section class="options-section">
+          <h4>Comment colors</h4>
+          <div class="options-row">
+            <label><input type="checkbox" id="options-comments-enabled" /> Enable comment highlighting</label>
+          </div>
+          <div id="options-comment-color-fields"></div>
+        </section>
+        <section class="options-section">
+          <h4>Box name styling (output)</h4>
+          <div class="options-row">
+            <label><input type="checkbox" id="options-boxnames-enabled" /> Enable box name styling</label>
+          </div>
+          <div class="options-row">
+            <label><input type="checkbox" id="options-box-number-bold" /> Bold numbers</label>
+            <label><input type="checkbox" id="options-box-symbol-bold" /> Bold symbols</label>
+          </div>
+          <div id="options-box-color-fields"></div>
+        </section>
+      </div>
+    </div>
   </body>
 </html>

--- a/html/index_rs.html
+++ b/html/index_rs.html
@@ -1,27 +1,33 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
   <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pokemon Ruby/Sapphire ACE generator</title>
-    <link rel="stylesheet" href="style.css">
-    <link rel="stylesheet" href="autocomplete.css">
-    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.min.css" rel="stylesheet">
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="options.css" />
+    <link rel="stylesheet" href="autocomplete.css" />
+    <link href="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/css/tom-select.min.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/tom-select@2.4.3/dist/js/tom-select.complete.min.js"></script>
     <script src="ace_js.bc.js?2"></script>
     <script src="config.js"></script>
+    <script src="fuzzysearch.js"></script>
+    <script src="options.js"></script>
     <script src="scripts.js"></script>
+    <script src="highlight.js"></script>
     <script src="ids.js"></script>
     <script src="autocomplete.js"></script>
   </head>
   <body>
-    <input type="hidden" id="script_workspace" value="files_rs">
+    <input type="hidden" id="script_workspace" value="files_rs" />
     <div class="row">
       <div id="mainTab" class="column grow tabcontent-active">
-        <h2><a class="tablinks-active">Main code</a> /
-            <a class="tablinks" onclick="openTab(event,'secondaryTab');">Exit codes</a>
-            (<a href="doc/index.html">documentation</a>)</h2>
-        
+        <h2>
+          <a class="tablinks-active">Main code</a> /
+          <a class="tablinks" onclick="openTab(event, 'secondaryTab')">Exit codes</a>
+          (<a href="doc/index.html">documentation</a>)
+        </h2>
+
         <div class="row">
           <select id="lang" class="left">
             <option value="eng2">English 1.2</option>
@@ -42,12 +48,12 @@
             <option value="ruby">Ruby</option>
             <option value="sapp">Sapphire</option>
           </select>
-          <select style="display:none;" id="cat" class="middle">
+          <select style="display: none" id="cat" class="middle">
             <option value="">All categories</option>
           </select>
           <select id="select" class="right grow"></select>
         </div>
-        <div class="container grow" id="container">
+        <div class="container grow editor-wrap" id="container">
           <textarea id="main" spellcheck="false"></textarea>
         </div>
         <div class="row">
@@ -57,21 +63,92 @@
       </div>
 
       <div id="secondaryTab" class="column grow tabcontent">
-        <h2><a class="tablinks" onclick="openTab(event,'mainTab');">Main code</a> /
-            <a class="tablinks-active">Exit codes</a>
-            (<a href="doc/index.html">documentation</a>)</h2>
+        <h2>
+          <a class="tablinks" onclick="openTab(event, 'mainTab')">Main code</a> /
+          <a class="tablinks-active">Exit codes</a>
+          (<a href="doc/index.html">documentation</a>)
+        </h2>
 
-        <textarea id="secondary" class="grow" spellcheck="false"></textarea>
+        <div class="editor-wrap grow">
+          <textarea id="secondary" spellcheck="false"></textarea>
+        </div>
       </div>
-      
+
       <div class="column grow">
         <h2>Result</h2>
-        <textarea id="output" class="grow" spellcheck="false" readonly></textarea>
+        <div class="editor-wrap grow">
+          <textarea id="output" spellcheck="false" readonly></textarea>
+        </div>
       </div>
     </div>
-    <p><button id="theme-toggle" onclick="toggleTheme()" type="button">Dark mode</button></p>
-    <p>Generator for <a href="index.html">Emerald</a> / <a href="index_frlg.html">FRLG</a> / <a href="index_rs.html">RS</a>&nbsp;&nbsp;-&nbsp;&nbsp;<a href="https://github.com/E-Sh4rk/CodeGeneratorOffline">Offline version</a></p>
-    <p>RS ACE tutorials: <a href="https://youtu.be/3RFTRL22xxo">Video by Sleipnir17</a> - <a href="https://e-sh4rk.github.io/EmeraldACE_web/doc/RS_Short_Exit_Codes_Guide.pdf">Short exit code guide by Sleipnir17</a></p>
-    <p>Useful links: <a href="https://pastebin.com/u/Sleipnir17">Sleipnir's Pastebin</a> (plenty of ACE codes) - <a href="https://www.youtube.com/@PapaJefeYT/videos">Papa Jefé's Youtube</a> (ACE tutorials) - <a href="https://github.com/E-Sh4rk/PokeGlitzer">PokeGlitzer</a> (save editor for glitchers)</p>
+    <p><button id="options-button" type="button">Options</button></p>
+    <p>
+      Generator for <a href="index.html">Emerald</a> / <a href="index_frlg.html">FRLG</a> /
+      <a href="index_rs.html">RS</a>&nbsp;&nbsp;-&nbsp;&nbsp;<a href="https://github.com/E-Sh4rk/CodeGeneratorOffline"
+        >Offline version</a
+      >
+    </p>
+    <p>
+      RS ACE tutorials: <a href="https://youtu.be/3RFTRL22xxo">Video by Sleipnir17</a> -
+      <a href="https://e-sh4rk.github.io/EmeraldACE_web/doc/RS_Short_Exit_Codes_Guide.pdf"
+        >Short exit code guide by Sleipnir17</a
+      >
+    </p>
+    <p>
+      Useful links: <a href="https://pastebin.com/u/Sleipnir17">Sleipnir's Pastebin</a> (plenty of ACE codes) -
+      <a href="https://www.youtube.com/@PapaJefeYT/videos">Papa Jefé's Youtube</a> (ACE tutorials) -
+      <a href="https://github.com/E-Sh4rk/PokeGlitzer">PokeGlitzer</a> (save editor for glitchers)
+    </p>
+
+    <div id="options-modal" class="options-modal" role="dialog" aria-labelledby="options-title" aria-hidden="true">
+      <div class="options-modal__backdrop"></div>
+      <div class="options-modal__panel">
+        <div class="options-modal__header">
+          <h3 id="options-title">Options</h3>
+          <button type="button" class="options-modal__close" aria-label="Close">×</button>
+        </div>
+        <section class="options-section">
+          <h4>Theme</h4>
+          <div class="options-radio-group">
+            <label><input type="radio" name="theme" value="system" /> System</label>
+            <label><input type="radio" name="theme" value="light" /> Light</label>
+            <label><input type="radio" name="theme" value="dark" /> Dark</label>
+          </div>
+        </section>
+        <section class="options-section">
+          <h4>Default options (this page)</h4>
+          <div class="options-row">
+            <label for="options-default-lang">Language</label>
+            <select id="options-default-lang"></select>
+          </div>
+          <div class="options-row" id="options-default-game-row">
+            <label for="options-default-game">Game</label>
+            <select id="options-default-game"></select>
+          </div>
+          <div class="options-actions">
+            <button type="button" id="options-use-current">Use current selection</button>
+            <button type="button" id="options-save-defaults">Save as default for this page</button>
+          </div>
+        </section>
+        <section class="options-section">
+          <h4>Comment colors</h4>
+          <div class="options-row">
+            <label><input type="checkbox" id="options-comments-enabled" /> Enable comment highlighting</label>
+          </div>
+          <div id="options-comment-color-fields"></div>
+        </section>
+        <section class="options-section">
+          <h4>Box name styling (output)</h4>
+          <div class="options-row">
+            <label><input type="checkbox" id="options-boxnames-enabled" /> Enable box name styling</label>
+          </div>
+          <div class="options-row">
+            <label><input type="checkbox" id="options-box-number-bold" /> Bold numbers</label>
+            <label><input type="checkbox" id="options-box-symbol-bold" /> Bold symbols</label>
+          </div>
+          <div id="options-box-color-fields"></div>
+        </section>
+      </div>
+    </div>
   </body>
 </html>

--- a/html/options.css
+++ b/html/options.css
@@ -1,0 +1,234 @@
+:root {
+  --modal-bg: #fff;
+  --modal-border: #d0d0d0;
+  --modal-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  --section-border: #e0e0e0;
+  --modal-backdrop: rgba(0, 0, 0, 0.45);
+  --color-input-border: #d0d0d0;
+}
+
+html[data-theme="light"] {
+  --modal-bg: #fff;
+  --modal-border: #d0d0d0;
+  --modal-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+  --section-border: #e0e0e0;
+  --modal-backdrop: rgba(0, 0, 0, 0.45);
+  --color-input-border: #d0d0d0;
+}
+
+html[data-theme="dark"] {
+  --modal-bg: #2a2a2a;
+  --modal-border: #555;
+  --modal-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+  --section-border: #444;
+  --modal-backdrop: rgba(0, 0, 0, 0.55);
+  --color-input-border: #555;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) {
+    --modal-bg: #2a2a2a;
+    --modal-border: #555;
+    --modal-shadow: 0 8px 32px rgba(0, 0, 0, 0.45);
+    --section-border: #444;
+    --modal-backdrop: rgba(0, 0, 0, 0.55);
+    --color-input-border: #555;
+  }
+}
+
+#options-button {
+  min-width: unset;
+  padding: 2px 14px;
+}
+
+.options-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+}
+
+.options-modal--open {
+  display: block;
+}
+
+.options-modal__backdrop {
+  position: absolute;
+  inset: 0;
+  background: var(--modal-backdrop);
+}
+
+.options-modal__panel {
+  position: relative;
+  margin: 2rem auto;
+  max-width: 640px;
+  max-height: calc(100vh - 4rem);
+  overflow-y: auto;
+  background: var(--modal-bg);
+  border: 1px solid var(--modal-border);
+  border-radius: var(--control-border-radius);
+  padding: 1rem 1.25rem;
+  box-shadow: var(--modal-shadow);
+  color: var(--body-text);
+}
+
+.options-modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 1rem;
+}
+
+.options-modal__header h3 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.options-modal__close {
+  min-width: unset;
+  padding: 2px 10px;
+  font-size: 1.2rem;
+  line-height: 1;
+}
+
+.options-section {
+  margin-bottom: 1.25rem;
+  padding-bottom: 1rem;
+  border-bottom: 1px solid var(--section-border);
+}
+
+.options-section:last-child {
+  border-bottom: none;
+  margin-bottom: 0;
+  padding-bottom: 0;
+}
+
+.options-section h4 {
+  margin: 0 0 0.6rem 0;
+  font-size: 0.95rem;
+}
+
+.options-palette-grid {
+  --options-palette-label-width: minmax(7.5rem, 1fr);
+  --options-palette-color-width: 2.5rem;
+  display: grid;
+  grid-template-columns:
+    var(--options-palette-label-width)
+    var(--options-palette-color-width)
+    var(--options-palette-color-width);
+  column-gap: 0.75rem;
+  row-gap: 0.4rem;
+  align-items: center;
+}
+
+.options-palette-grid__headings {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  margin-bottom: 0.15rem;
+}
+
+.options-palette-grid__headings span {
+  font-size: 0.85rem;
+  font-weight: bold;
+  opacity: 0.85;
+}
+
+.options-palette-grid__headings .options-palette-grid__label-spacer {
+  grid-column: 1;
+}
+
+.options-palette-grid__headings span:nth-child(2) {
+  grid-column: 2;
+  text-align: center;
+}
+
+.options-palette-grid__headings span:nth-child(3) {
+  grid-column: 3;
+  text-align: center;
+}
+
+.options-palette-grid__row {
+  display: grid;
+  grid-column: 1 / -1;
+  grid-template-columns: subgrid;
+  align-items: center;
+}
+
+.options-palette-grid__name {
+  grid-column: 1;
+  font-size: 0.85rem;
+  min-width: 0;
+}
+
+.options-palette-grid__row > input:nth-child(2) {
+  grid-column: 2;
+}
+
+.options-palette-grid__row > input:nth-child(3) {
+  grid-column: 3;
+}
+
+.options-palette-grid input[type="color"] {
+  width: var(--options-palette-color-width);
+  height: 1.6rem;
+  padding: 0;
+  border: 1px solid var(--color-input-border);
+  cursor: pointer;
+  background: transparent;
+  box-sizing: border-box;
+}
+
+.options-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.4rem;
+  flex-wrap: wrap;
+}
+
+.options-row label {
+  min-width: 7rem;
+  font-size: 0.9rem;
+}
+
+.options-row input[type="color"] {
+  width: 2.5rem;
+  height: 1.6rem;
+  padding: 0;
+  border: 1px solid var(--color-input-border);
+  cursor: pointer;
+  background: transparent;
+}
+
+.options-row select {
+  flex: 1;
+  min-width: 8rem;
+}
+
+.options-radio-group {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.options-radio-group label {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-size: 0.9rem;
+  min-width: unset;
+}
+
+.options-actions {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  margin-top: 0.5rem;
+}
+
+.options-actions button {
+  min-width: unset;
+  padding: 4px 12px;
+  font-size: 0.85rem;
+}

--- a/html/options.js
+++ b/html/options.js
@@ -1,0 +1,482 @@
+const Options = (() => {
+  const STORAGE_KEY = "acegen-options";
+
+  const COLOR_PRESETS = {
+    light: {
+      comments: {
+        semicolon: "#1a7f37",
+        slash: "#1a7f37",
+        percent: "#0550ae",
+        header: "#8250df",
+      },
+      boxNames: {
+        number: "#0e7490",
+        symbol: "#cf222e",
+        letter: "#6639ba",
+        bracket: "#bc4c00",
+        label: "#57606a",
+      },
+    },
+    dark: {
+      comments: {
+        semicolon: "#7ee787",
+        slash: "#7ee787",
+        percent: "#79c0ff",
+        header: "#d2a8ff",
+      },
+      boxNames: {
+        number: "#56d4dd",
+        symbol: "#ff8a80",
+        letter: "#e8b4f8",
+        bracket: "#ffa657",
+        label: "#8b949e",
+      },
+    },
+  };
+
+  const COMMENT_COLOR_FIELDS = [
+    { key: "semicolon", label: "; comments" },
+    { key: "slash", label: "// comments" },
+    { key: "percent", label: "%% annotations" },
+    { key: "header", label: "@@ headers" },
+  ];
+
+  const BOX_COLOR_FIELDS = [
+    { key: "label", label: "Box label" },
+    { key: "number", label: "Numbers" },
+    { key: "symbol", label: "Symbols" },
+    { key: "letter", label: "Letters" },
+    { key: "bracket", label: "Brackets" },
+  ];
+
+  const DEFAULTS = {
+    theme: "system",
+    defaults: {
+      emerald: { lang: "eng", game: "" },
+      frlg: { lang: "eng1", game: "fr" },
+      rs: { lang: "eng2", game: "ruby" },
+    },
+    comments: { enabled: true },
+    boxNames: {
+      enabled: true,
+      numberBold: false,
+      symbolBold: false,
+    },
+    colors: {
+      light: deepClone(COLOR_PRESETS.light),
+      dark: deepClone(COLOR_PRESETS.dark),
+    },
+  };
+
+  const PAGE_IDS = {
+    files: "emerald",
+    files_frlg: "frlg",
+    files_rs: "rs",
+  };
+
+  let settings = null;
+  let colorFieldsBuilt = false;
+
+  function deepClone(obj) {
+    return JSON.parse(JSON.stringify(obj));
+  }
+
+  function deepMerge(base, override) {
+    const result = { ...base };
+    for (const key of Object.keys(override)) {
+      if (override[key] && typeof override[key] === "object" && !Array.isArray(override[key])) {
+        result[key] = deepMerge(base[key] || {}, override[key]);
+      } else if (override[key] !== undefined) {
+        result[key] = override[key];
+      }
+    }
+    return result;
+  }
+
+  function migrateStored(stored) {
+    const merged = deepMerge(DEFAULTS, stored);
+
+    if (!stored.colors) {
+      merged.colors = deepClone(DEFAULTS.colors);
+
+      if (stored.comments) {
+        merged.comments.enabled = stored.comments.enabled ?? true;
+        const commentColors = pickColorKeys(stored.comments, COMMENT_COLOR_FIELDS);
+        if (Object.keys(commentColors).length > 0) {
+          merged.colors.dark.comments = { ...merged.colors.dark.comments, ...commentColors };
+        }
+      }
+      if (stored.boxNames) {
+        merged.boxNames.enabled = stored.boxNames.enabled ?? true;
+        merged.boxNames.numberBold = stored.boxNames.numberBold ?? false;
+        merged.boxNames.symbolBold = stored.boxNames.symbolBold ?? false;
+        const boxColors = pickColorKeys(stored.boxNames, BOX_COLOR_FIELDS);
+        if (Object.keys(boxColors).length > 0) {
+          merged.colors.dark.boxNames = { ...merged.colors.dark.boxNames, ...boxColors };
+        }
+      }
+    }
+
+    merged.comments = { enabled: merged.comments?.enabled ?? true };
+    merged.boxNames = {
+      enabled: merged.boxNames?.enabled ?? true,
+      numberBold: merged.boxNames?.numberBold ?? false,
+      symbolBold: merged.boxNames?.symbolBold ?? false,
+    };
+
+    return merged;
+  }
+
+  function pickColorKeys(source, fields) {
+    const out = {};
+    for (const field of fields) {
+      if (source[field.key]) out[field.key] = source[field.key];
+    }
+    return out;
+  }
+
+  function load() {
+    if (settings) return settings;
+    let stored = {};
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (raw) stored = JSON.parse(raw);
+    } catch (_) {
+      stored = {};
+    }
+    const legacyTheme = localStorage.getItem("theme");
+    if (!stored.theme && (legacyTheme === "light" || legacyTheme === "dark")) {
+      stored.theme = legacyTheme;
+    }
+    settings = migrateStored(stored);
+    return settings;
+  }
+
+  function save() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
+    localStorage.removeItem("theme");
+  }
+
+  function getPageId() {
+    const ws = document.getElementById("script_workspace");
+    if (!ws) return "emerald";
+    return PAGE_IDS[ws.value] || "emerald";
+  }
+
+  function getResolvedColorMode() {
+    const s = load();
+    if (s.theme === "dark") return "dark";
+    if (s.theme === "light") return "light";
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  }
+
+  function applyTheme() {
+    const s = load();
+    if (s.theme === "system") {
+      document.documentElement.removeAttribute("data-theme");
+    } else {
+      document.documentElement.setAttribute("data-theme", s.theme);
+    }
+  }
+
+  function applyBodyClasses() {
+    if (!document.body) return;
+    const s = load();
+    document.body.classList.toggle("comments-highlight-off", !s.comments.enabled);
+    document.body.classList.toggle("boxnames-highlight-off", !s.boxNames.enabled);
+  }
+
+  function applyCssVariables() {
+    const s = load();
+    const mode = getResolvedColorMode();
+    const palette = s.colors[mode];
+    const root = document.documentElement;
+
+    root.style.setProperty("--comment-semicolon", palette.comments.semicolon);
+    root.style.setProperty("--comment-slash", palette.comments.slash);
+    root.style.setProperty("--comment-percent", palette.comments.percent);
+    root.style.setProperty("--comment-header", palette.comments.header);
+    root.style.setProperty("--box-number", palette.boxNames.number);
+    root.style.setProperty("--box-symbol", palette.boxNames.symbol);
+    root.style.setProperty("--box-letter", palette.boxNames.letter);
+    root.style.setProperty("--box-bracket", palette.boxNames.bracket);
+    root.style.setProperty("--box-label", palette.boxNames.label);
+    root.style.setProperty("--box-number-weight", s.boxNames.numberBold ? "bold" : "normal");
+    root.style.setProperty("--box-symbol-weight", s.boxNames.symbolBold ? "bold" : "normal");
+    applyBodyClasses();
+  }
+
+  function apply() {
+    applyTheme();
+    applyCssVariables();
+    if (typeof Highlight !== "undefined") Highlight.refreshAll();
+  }
+
+  function getDefaultsForPage(pageId) {
+    const s = load();
+    return s.defaults[pageId] || null;
+  }
+
+  function saveDefaultsForPage(pageId, lang, game) {
+    const s = load();
+    s.defaults[pageId] = { lang, game };
+    save();
+  }
+
+  function resolveLangGame(url) {
+    const pageId = getPageId();
+    const langEl = document.getElementById("lang");
+    const gameEl = document.getElementById("game");
+    if (!langEl) return;
+
+    const langParam = url.searchParams.get("lang");
+    const gameParam = url.searchParams.get("game");
+
+    if (!langParam) {
+      const saved = getDefaultsForPage(pageId);
+      if (saved && saved.lang && [...langEl.options].some((o) => o.value === saved.lang)) {
+        langEl.value = saved.lang;
+      }
+    }
+    if (!gameParam && gameEl) {
+      const saved = getDefaultsForPage(pageId);
+      if (saved && saved.game !== undefined && [...gameEl.options].some((o) => o.value === saved.game)) {
+        gameEl.value = saved.game;
+      }
+    }
+  }
+
+  function populateSelect(selectEl, sourceEl) {
+    if (!selectEl || !sourceEl) return;
+    selectEl.innerHTML = "";
+    for (const opt of sourceEl.options) {
+      const o = document.createElement("option");
+      o.value = opt.value;
+      o.textContent = opt.textContent;
+      selectEl.appendChild(o);
+    }
+  }
+
+  function colorInputId(group, key, mode) {
+    return `options-${group}-${key}-${mode}`;
+  }
+
+  function buildPaletteGrid(group, fields) {
+    const grid = document.createElement("div");
+    grid.className = "options-palette-grid";
+
+    const headings = document.createElement("div");
+    headings.className = "options-palette-grid__headings";
+    headings.innerHTML =
+      "<span class=\"options-palette-grid__label-spacer\"></span><span>Light</span><span>Dark</span>";
+    grid.appendChild(headings);
+
+    for (const field of fields) {
+      const row = document.createElement("div");
+      row.className = "options-palette-grid__row";
+
+      const name = document.createElement("span");
+      name.className = "options-palette-grid__name";
+      name.textContent = field.label;
+      row.appendChild(name);
+
+      for (const mode of ["light", "dark"]) {
+        const id = colorInputId(group, field.key, mode);
+        const input = document.createElement("input");
+        input.type = "color";
+        input.id = id;
+        input.title = `${field.label} (${mode} theme)`;
+        input.setAttribute("aria-label", `${field.label}, ${mode} theme`);
+        input.dataset.group = group;
+        input.dataset.key = field.key;
+        input.dataset.mode = mode;
+        row.appendChild(input);
+      }
+
+      grid.appendChild(row);
+    }
+
+    return grid;
+  }
+
+  function buildColorPaletteFields() {
+    if (colorFieldsBuilt) return;
+
+    const commentContainer = document.getElementById("options-comment-color-fields");
+    const boxContainer = document.getElementById("options-box-color-fields");
+    if (!commentContainer || !boxContainer) return;
+
+    commentContainer.appendChild(buildPaletteGrid("comment", COMMENT_COLOR_FIELDS));
+    boxContainer.appendChild(buildPaletteGrid("box", BOX_COLOR_FIELDS));
+
+    const modal = document.getElementById("options-modal");
+    modal.querySelectorAll('input[type="color"][data-mode]').forEach((el) => {
+      el.addEventListener("change", readFormIntoSettings);
+    });
+
+    colorFieldsBuilt = true;
+  }
+
+  function syncFormFromSettings() {
+    const s = load();
+    const modal = document.getElementById("options-modal");
+    if (!modal) return;
+
+    buildColorPaletteFields();
+
+    modal.querySelectorAll('input[name="theme"]').forEach((r) => {
+      r.checked = r.value === s.theme;
+    });
+
+    const langSelect = document.getElementById("options-default-lang");
+    const gameSelect = document.getElementById("options-default-game");
+    const pageLang = document.getElementById("lang");
+    const pageGame = document.getElementById("game");
+    populateSelect(langSelect, pageLang);
+    populateSelect(gameSelect, pageGame);
+
+    const pageId = getPageId();
+    const saved = s.defaults[pageId];
+    if (saved) {
+      if (langSelect && [...langSelect.options].some((o) => o.value === saved.lang)) {
+        langSelect.value = saved.lang;
+      }
+      if (gameSelect && saved.game !== undefined && [...gameSelect.options].some((o) => o.value === saved.game)) {
+        gameSelect.value = saved.game;
+      }
+    }
+
+    const setChecked = (id, val) => {
+      const el = document.getElementById(id);
+      if (el) el.checked = val;
+    };
+
+    setChecked("options-comments-enabled", s.comments.enabled);
+    setChecked("options-boxnames-enabled", s.boxNames.enabled);
+    setChecked("options-box-number-bold", s.boxNames.numberBold);
+    setChecked("options-box-symbol-bold", s.boxNames.symbolBold);
+
+    for (const mode of ["light", "dark"]) {
+      for (const field of COMMENT_COLOR_FIELDS) {
+        const el = document.getElementById(colorInputId("comment", field.key, mode));
+        if (el) el.value = s.colors[mode].comments[field.key];
+      }
+      for (const field of BOX_COLOR_FIELDS) {
+        const el = document.getElementById(colorInputId("box", field.key, mode));
+        if (el) el.value = s.colors[mode].boxNames[field.key];
+      }
+    }
+
+    const gameRow = document.getElementById("options-default-game-row");
+    if (gameRow && pageGame) {
+      gameRow.style.display = pageGame.style.display === "none" ? "none" : "";
+    }
+  }
+
+  function readFormIntoSettings() {
+    const s = load();
+    const themeRadio = document.querySelector('input[name="theme"]:checked');
+    if (themeRadio) s.theme = themeRadio.value;
+
+    s.comments.enabled = document.getElementById("options-comments-enabled").checked;
+    s.boxNames.enabled = document.getElementById("options-boxnames-enabled").checked;
+    s.boxNames.numberBold = document.getElementById("options-box-number-bold").checked;
+    s.boxNames.symbolBold = document.getElementById("options-box-symbol-bold").checked;
+
+    for (const mode of ["light", "dark"]) {
+      for (const field of COMMENT_COLOR_FIELDS) {
+        const el = document.getElementById(colorInputId("comment", field.key, mode));
+        if (el) s.colors[mode].comments[field.key] = el.value;
+      }
+      for (const field of BOX_COLOR_FIELDS) {
+        const el = document.getElementById(colorInputId("box", field.key, mode));
+        if (el) s.colors[mode].boxNames[field.key] = el.value;
+      }
+    }
+
+    save();
+    apply();
+  }
+
+  function openModal() {
+    syncFormFromSettings();
+    document.getElementById("options-modal").classList.add("options-modal--open");
+  }
+
+  function closeModal() {
+    document.getElementById("options-modal").classList.remove("options-modal--open");
+  }
+
+  function initModal() {
+    const btn = document.getElementById("options-button");
+    if (btn) btn.addEventListener("click", openModal);
+
+    const modal = document.getElementById("options-modal");
+    if (!modal) return;
+
+    buildColorPaletteFields();
+
+    modal.querySelector(".options-modal__backdrop").addEventListener("click", closeModal);
+    modal.querySelector(".options-modal__close").addEventListener("click", closeModal);
+
+    modal.querySelectorAll('input[name="theme"]').forEach((el) => {
+      el.addEventListener("change", readFormIntoSettings);
+    });
+
+    [
+      "options-comments-enabled",
+      "options-boxnames-enabled",
+      "options-box-number-bold",
+      "options-box-symbol-bold",
+    ].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.addEventListener("change", readFormIntoSettings);
+    });
+
+    document.getElementById("options-save-defaults").addEventListener("click", () => {
+      const langSelect = document.getElementById("options-default-lang");
+      const gameSelect = document.getElementById("options-default-game");
+      saveDefaultsForPage(getPageId(), langSelect.value, gameSelect ? gameSelect.value : "");
+      const pageLang = document.getElementById("lang");
+      const pageGame = document.getElementById("game");
+      if (pageLang) pageLang.value = langSelect.value;
+      if (pageGame && gameSelect) pageGame.value = gameSelect.value;
+      if (typeof window.onDefaultsChanged === "function") window.onDefaultsChanged();
+    });
+
+    document.getElementById("options-use-current").addEventListener("click", () => {
+      const pageLang = document.getElementById("lang");
+      const pageGame = document.getElementById("game");
+      const langSelect = document.getElementById("options-default-lang");
+      const gameSelect = document.getElementById("options-default-game");
+      if (pageLang && langSelect) langSelect.value = pageLang.value;
+      if (pageGame && gameSelect) gameSelect.value = pageGame.value;
+    });
+  }
+
+  load();
+  applyTheme();
+  applyCssVariables();
+
+  window.matchMedia("(prefers-color-scheme: dark)").addEventListener("change", () => {
+    if (load().theme === "system") apply();
+  });
+
+  window.addEventListener("DOMContentLoaded", () => {
+    applyBodyClasses();
+    initModal();
+  });
+
+  return {
+    load,
+    save,
+    apply,
+    getPageId,
+    getResolvedColorMode,
+    getDefaultsForPage,
+    saveDefaultsForPage,
+    resolveLangGame,
+    openModal,
+    closeModal,
+  };
+})();

--- a/html/scripts.js
+++ b/html/scripts.js
@@ -1,196 +1,203 @@
-(function () {
-    const saved = localStorage.getItem('theme');
-    if (saved) document.documentElement.setAttribute('data-theme', saved);
-})();
+window.addEventListener("load", () => {
+  const url = new URL(window.location.href);
+  let workspace = repository + document.getElementById("script_workspace").value;
+  let prefix_for_examples = workspace + "/";
+  let list_path = prefix_for_examples + "list.json";
+  let empty_path = prefix_for_examples + "empty.txt";
+  let exit_codes_path = prefix_for_examples + "exit.txt";
+  let code = document.getElementById("main");
+  let exit_codes = document.getElementById("secondary");
+  let select = document.getElementById("select");
+  let lang = document.getElementById("lang");
+  let cat = document.getElementById("cat");
+  let game = document.getElementById("game");
 
-function toggleTheme() {
-    const current = document.documentElement.getAttribute('data-theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const isDark = current === 'dark' || (current === null && prefersDark);
-    const next = isDark ? 'light' : 'dark';
-    document.documentElement.setAttribute('data-theme', next);
-    localStorage.setItem('theme', next);
-    updateThemeButton();
-}
+  let ts = new TomSelect(select, {
+    create: false,
+    maxOptions: null,
+    placeholder: "----------",
+    wrapperClass: "ts-wrapper right grow",
+    sortField: { field: "$order", direction: "asc" },
+    score: function (search) {
+      const term = search.toLowerCase().trim();
+      return function (item) {
+        return FuzzySearch.tomSelectScore(term, item.text);
+      };
+    },
+  });
 
-function updateThemeButton() {
-    const btn = document.getElementById('theme-toggle');
-    if (!btn) return;
-    const current = document.documentElement.getAttribute('data-theme');
-    const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const isDark = current === 'dark' || (current === null && prefersDark);
-    btn.textContent = isDark ? 'Light mode' : 'Dark mode';
-}
+  let lock = false;
+  let examples = null;
+  let last_selected_example = "";
 
-window.addEventListener ("load", () => {
-    updateThemeButton();
-    const url = new URL(window.location.href);
-    let workspace = repository + document.getElementById ("script_workspace").value;
-    let prefix_for_examples = workspace + "/";
-    let list_path = prefix_for_examples+"list.json";
-    let empty_path = prefix_for_examples+"empty.txt";
-    let exit_codes_path = prefix_for_examples+"exit.txt";
-    let code = document.getElementById ("main");
-    let exit_codes = document.getElementById ("secondary");
-    let select = document.getElementById ("select");
-    let lang = document.getElementById ("lang");
-    let cat = document.getElementById ("cat");
-    let game = document.getElementById ("game");
-
-    let ts = new TomSelect(select, {
-        create: false,
-        maxOptions: null,
-        placeholder: '----------',
-        wrapperClass: 'ts-wrapper right grow',
-        sortField: { field: '$order', direction: 'asc' },
-    });
-
-    let lock = false;
-    let examples = null;
-    let last_selected_example = "";
-
-    function getFile(url, success_callback, callback) {
-        lock = true;
-        let xhr = new XMLHttpRequest();
-        xhr.open("GET", url);
-        // xhr.setRequestHeader("Cache-Control", "no-cache");
-        xhr.setRequestHeader("Cache-Control", "max-age=0");
-        xhr.overrideMimeType("text/plain");
-        xhr.addEventListener("readystatechange", () => {
-            if (xhr.readyState == 4) {
-                if (xhr.status == 200)  {
-                    success_callback(xhr.responseText);
-                } else {
-                    console.log("Unknown file " + url);
-                }
-                lock = false;
-                if (callback) callback();
-            }
-        });
-        xhr.send();
-    };
-
-    function fileToField(url, field, callback) {
-        getFile(url, (content) => {
-			let langr = lang.value;
-			let langnr = langr.substring(0,3);
-			let gamev = game.value;
-            let str = content.replaceAll("{LANG}", langr.toUpperCase());
-            str = str.replaceAll("{lang}", langr.toLowerCase());
-			str = str.replaceAll("{LANGNR}", langnr.toUpperCase());
-			str = str.replaceAll("{langnr}", langnr.toLowerCase());
-            str = str.replaceAll("{GAME}", gamev.toUpperCase());
-            str = str.replaceAll("{game}", gamev.toLowerCase());
-            field.value = str;
-        }, callback);
+  function refreshHighlights() {
+    if (typeof Highlight !== "undefined") {
+      Highlight.refresh("main");
+      Highlight.refresh("secondary");
+      Highlight.refresh("output");
     }
+  }
 
-    function updateCode() {
-        if (examples == null) return;
-        if (!lock) {
-            if (select.value) {
-                let obj = examples[parseInt(select.value)];
-                fileToField(prefix_for_examples + obj[lang.value], code, null);
-            }
-            else {
-                fileToField(empty_path, code, null);
-            }
+  function getFile(url, success_callback, callback) {
+    lock = true;
+    let xhr = new XMLHttpRequest();
+    xhr.open("GET", url);
+    // xhr.setRequestHeader("Cache-Control", "no-cache");
+    xhr.setRequestHeader("Cache-Control", "max-age=0");
+    xhr.overrideMimeType("text/plain");
+    xhr.addEventListener("readystatechange", () => {
+      if (xhr.readyState == 4) {
+        if (xhr.status == 200) {
+          success_callback(xhr.responseText);
+        } else {
+          console.log("Unknown file " + url);
         }
+        lock = false;
+        if (callback) callback();
+      }
+    });
+    xhr.send();
+  }
+
+  function fileToField(url, field, callback) {
+    getFile(
+      url,
+      (content) => {
+        let langr = lang.value;
+        let langnr = langr.substring(0, 3);
+        let gamev = game.value;
+        let str = content.replaceAll("{LANG}", langr.toUpperCase());
+        str = str.replaceAll("{lang}", langr.toLowerCase());
+        str = str.replaceAll("{LANGNR}", langnr.toUpperCase());
+        str = str.replaceAll("{langnr}", langnr.toLowerCase());
+        str = str.replaceAll("{GAME}", gamev.toUpperCase());
+        str = str.replaceAll("{game}", gamev.toLowerCase());
+        field.value = str;
+        refreshHighlights();
+      },
+      callback,
+    );
+  }
+
+  function updateCode() {
+    if (examples == null) return;
+    if (!lock) {
+      if (select.value) {
+        let obj = examples[parseInt(select.value)];
+        fileToField(prefix_for_examples + obj[lang.value], code, null);
+      } else {
+        fileToField(empty_path, code, null);
+      }
     }
+  }
 
-    function updateSelectField() {
-        if (examples == null) return;
+  function updateSelectField() {
+    if (examples == null) return;
 
-        let language = lang.value;
-        let gam = game.value;
-        let category = cat.value;
-        let options = [];
-        let newSelectedValue = '';
-        examples.forEach((element,index) => {
-            if (language in element
-                && (category == "" || ("cat" in element && element["cat"].includes(category)))
-                && (gam == "" || ("game" in element && element["game"].includes(gam)))) {
-                let val = index.toString();
-                if (val == last_selected_example) newSelectedValue = val;
-                options.push({ value: val, text: element["name"] });
-            }
-        });
-
-        ts.clear(true);
-        ts.clearOptions();
-        options.forEach(o => ts.addOption(o));
-        ts.setValue(newSelectedValue, true);
-
-        updateCode();
-    }
-
-    function loadExamples(callback) {
-        getFile(list_path, (content) => {
-            examples = JSON.parse(content);
-            updateSelectField();
-        }, callback);
-    }
-
-    function langChanged() {
-        url.searchParams.set('lang', lang.value);
-        window.history.replaceState(null, null, url);
-        updateSelectField();
-    }
-    function gameChanged() {
-        url.searchParams.set('game', game.value);
-        window.history.replaceState(null, null, url);
-        updateSelectField();
-    }
-
-    let langval = url.searchParams.get('lang');
-    if (langval)
-        lang.value = langval;
-
-    let gameval = url.searchParams.get('game');
-    if (gameval)
-        game.value = gameval;
-
-    ts.on('change', (value) => {
-        last_selected_example = value;
-        updateCode();
+    let language = lang.value;
+    let gam = game.value;
+    let category = cat.value;
+    let options = [];
+    let newSelectedValue = "";
+    examples.forEach((element, index) => {
+      if (
+        language in element &&
+        (category == "" || ("cat" in element && element["cat"].includes(category))) &&
+        (gam == "" || ("game" in element && element["game"].includes(gam)))
+      ) {
+        let val = index.toString();
+        if (val == last_selected_example) newSelectedValue = val;
+        options.push({ value: val, text: element["name"] });
+      }
     });
 
-    lang.addEventListener ("change", langChanged);
-    game.addEventListener ("change", gameChanged);
-    cat.addEventListener ("change", updateSelectField);
+    ts.clear(true);
+    ts.clearOptions();
+    options.forEach((o) => ts.addOption(o));
+    ts.setValue(newSelectedValue, true);
 
-    fileToField(exit_codes_path, exit_codes, () => {
-        fileToField(empty_path, code, () => {loadExamples(null);});
+    updateCode();
+  }
+
+  function loadExamples(callback) {
+    getFile(
+      list_path,
+      (content) => {
+        examples = JSON.parse(content);
+        updateSelectField();
+      },
+      callback,
+    );
+  }
+
+  function langChanged() {
+    url.searchParams.set("lang", lang.value);
+    window.history.replaceState(null, null, url);
+    updateSelectField();
+  }
+  function gameChanged() {
+    url.searchParams.set("game", game.value);
+    window.history.replaceState(null, null, url);
+    updateSelectField();
+  }
+
+  Options.resolveLangGame(url);
+
+  let langval = url.searchParams.get("lang");
+  if (langval) lang.value = langval;
+
+  let gameval = url.searchParams.get("game");
+  if (gameval) game.value = gameval;
+
+  window.onDefaultsChanged = () => {
+    updateSelectField();
+  };
+
+  ts.on("change", (value) => {
+    last_selected_example = value;
+    updateCode();
+  });
+
+  lang.addEventListener("change", langChanged);
+  game.addEventListener("change", gameChanged);
+  cat.addEventListener("change", updateSelectField);
+
+  fileToField(exit_codes_path, exit_codes, () => {
+    fileToField(empty_path, code, () => {
+      loadExamples(null);
     });
+  });
 });
 
 /* ===== TABS ===== */
 
 function openTab(_, id) {
-    let active = document.getElementsByClassName("tabcontent-active")[0];
-    active.className = active.className.replace("tabcontent-active", "tabcontent");
-    let target = document.getElementById(id);
-    target.className = target.className.replace("tabcontent", "tabcontent-active");
+  let active = document.getElementsByClassName("tabcontent-active")[0];
+  active.className = active.className.replace("tabcontent-active", "tabcontent");
+  let target = document.getElementById(id);
+  target.className = target.className.replace("tabcontent", "tabcontent-active");
 }
 
 /* ===== COMPUTE ===== */
 
 function compute() {
-    let lang = document.getElementById ("lang");
-    let game = document.getElementById ("game");
-    let main = document.getElementById ("main");
-    let secondary = document.getElementById ("secondary");
-    let [_, txt] = aceGen.build(lang.value, game.value, main.value, secondary.value);
-    let output = document.getElementById ("output");
-    output.value = txt;
+  let lang = document.getElementById("lang");
+  let game = document.getElementById("game");
+  let main = document.getElementById("main");
+  let secondary = document.getElementById("secondary");
+  let [_, txt] = aceGen.build(lang.value, game.value, main.value, secondary.value);
+  let output = document.getElementById("output");
+  output.value = txt;
+  if (typeof Highlight !== "undefined") Highlight.refresh("output");
 }
 
 function computeNext() {
-    let lang = document.getElementById ("lang");
-    let game = document.getElementById ("game");
-    let main = document.getElementById ("main");
-    let secondary = document.getElementById ("secondary");
-    let [_, txt] = aceGen.buildNext(lang.value, game.value, main.value, secondary.value);
-    let output = document.getElementById ("output");
-    output.value = txt;
+  let lang = document.getElementById("lang");
+  let game = document.getElementById("game");
+  let main = document.getElementById("main");
+  let secondary = document.getElementById("secondary");
+  let [_, txt] = aceGen.buildNext(lang.value, game.value, main.value, secondary.value);
+  let output = document.getElementById("output");
+  output.value = txt;
+  if (typeof Highlight !== "undefined") Highlight.refresh("output");
 }

--- a/html/style.css
+++ b/html/style.css
@@ -166,6 +166,20 @@ html[data-theme="dark"] {
   }
 }
 
+html {
+  color-scheme: light;
+}
+
+html[data-theme="dark"] {
+  color-scheme: dark;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) {
+    color-scheme: dark;
+  }
+}
+
 textarea {
   font-family: "Consolas", "Yu Gothic", "Courier New";
   height: 100%;
@@ -182,6 +196,19 @@ textarea:not(.editor--highlighted) {
   border: 1px solid var(--control-border);
 }
 
+textarea:focus {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
+.editor-wrap > textarea:focus,
+.container.editor-wrap > textarea:focus {
+  outline: none;
+}
+
+.editor-wrap:focus-within {
+  outline: -webkit-focus-ring-color auto 1px;
+}
+
 .editor-wrap {
   position: relative;
   flex-grow: 1;
@@ -189,6 +216,25 @@ textarea:not(.editor--highlighted) {
   min-width: 400px;
   resize: both;
   overflow: hidden;
+}
+
+.editor-wrap::-webkit-resizer,
+textarea::-webkit-resizer {
+  background-color: var(--control-bg);
+  background-image: linear-gradient(
+    135deg,
+    transparent 0 44%,
+    var(--control-border) 44% 48%,
+    transparent 48% 56%,
+    var(--control-border) 56% 60%,
+    transparent 60% 68%,
+    var(--control-border) 68% 72%,
+    transparent 72%
+  );
+}
+
+.editor-wrap::-webkit-resizer {
+  background-color: var(--editor-bg);
 }
 
 .editor-wrap > textarea,

--- a/html/style.css
+++ b/html/style.css
@@ -1,223 +1,431 @@
 * {
-    font-family: Arial, Helvetica, sans-serif;
+  font-family: Arial, Helvetica, sans-serif;
 }
 
 h2 {
-    font-size: large;
-    margin: 5px;
+  font-size: large;
+  margin: 5px;
 }
 
 a {
   display: inline-block;
+  color: var(--link-color);
+}
+
+body {
+  background-color: var(--body-bg);
+  color: var(--body-text);
 }
 
 select {
-    background-color: #fff;
-    border: 1px solid #d0d0d0;
-    border-radius: 3px;
-    padding: 1px 6px;
-    height: unset;
+  background-color: var(--control-bg);
+  color: var(--control-text);
+  border: 1px solid var(--control-border);
+  border-radius: var(--select-border-radius);
+  padding: var(--select-padding-y) var(--select-padding-x);
+  height: unset;
+  box-sizing: border-box;
+  font-family: inherit;
+  font-size: var(--control-font-size);
+  line-height: var(--control-line-height);
 }
 
 button {
-    min-width: 200px;
+  min-width: 200px;
+  appearance: none;
+  background-color: var(--button-bg);
+  color: var(--button-text);
+  border: 1px solid var(--button-border);
+  border-radius: var(--control-border-radius);
+  box-shadow: none;
+  padding: var(--control-padding-y) var(--control-padding-x);
+  cursor: pointer;
+  font-family: inherit;
+  font-size: inherit;
+  line-height: normal;
+}
+
+button:hover {
+  background-color: var(--button-hover-bg);
+  border-color: var(--button-hover-border);
 }
 
 @font-face {
-  font-family: 'Consolas';
-  src: url('./consola.ttf') format('truetype');
+  font-family: "Consolas";
+  src: url("./consola.ttf") format("truetype");
 }
 
 @font-face {
-  font-family: 'Yu Gothic';
-  src: url('./YuGothic.ttf') format('truetype');
+  font-family: "Yu Gothic";
+  src: url("./YuGothic.ttf") format("truetype");
+}
+
+:root {
+  --control-border-radius: 6px;
+  --control-padding-y: 6px;
+  --control-padding-x: 12px;
+  --select-border-radius: 3px;
+  --select-padding-y: 2px;
+  --select-padding-x: 6px;
+  --control-font-size: 14px;
+  --control-line-height: 20px;
+
+  --body-bg: #fff;
+  --body-text: #000;
+  --link-color: blue;
+  --tab-link-color: blue;
+  --tab-active-color: #000;
+
+  --control-bg: #fff;
+  --control-text: #000;
+  --control-border: #d0d0d0;
+
+  --button-bg: #f6f8fa;
+  --button-text: #24292f;
+  --button-border: #d0d7de;
+  --button-hover-bg: #eaeef2;
+  --button-hover-border: #b0b8c0;
+
+  --surface-hover-bg: #eaeef2;
+  --option-hover-text: inherit;
+
+  --comment-semicolon: #6a9955;
+  --comment-slash: #6a9955;
+  --comment-percent: #569cd6;
+  --comment-header: #c586c0;
+  --box-number: #b5cea8;
+  --box-symbol: #dcdcaa;
+  --box-letter: #9cdcfe;
+  --box-bracket: #ce9178;
+  --box-label: #808080;
+  --box-number-weight: normal;
+  --box-symbol-weight: normal;
+  --editor-text: #000;
+  --editor-bg: #fff;
+}
+
+html[data-theme="light"] {
+  --body-bg: #fff;
+  --body-text: #000;
+  --link-color: blue;
+  --tab-link-color: blue;
+  --tab-active-color: #000;
+  --control-bg: #fff;
+  --control-text: #000;
+  --control-border: #d0d0d0;
+  --button-bg: #f6f8fa;
+  --button-text: #24292f;
+  --button-border: #d0d7de;
+  --button-hover-bg: #eaeef2;
+  --button-hover-border: #b0b8c0;
+  --surface-hover-bg: #eaeef2;
+  --option-hover-text: inherit;
+  --editor-text: #000;
+  --editor-bg: #fff;
+}
+
+html[data-theme="dark"] {
+  --body-bg: #1a1a1a;
+  --body-text: #e0e0e0;
+  --link-color: #6ab0f5;
+  --tab-link-color: #6ab0f5;
+  --tab-active-color: #e0e0e0;
+  --control-bg: #2a2a2a;
+  --control-text: #e0e0e0;
+  --control-border: #555;
+  --button-bg: #2a2a2a;
+  --button-text: #e0e0e0;
+  --button-border: #555;
+  --button-hover-bg: #3a3a3a;
+  --button-hover-border: #555;
+  --surface-hover-bg: #3a3a3a;
+  --option-hover-text: #fff;
+  --editor-text: #e0e0e0;
+  --editor-bg: #2a2a2a;
+}
+
+@media (prefers-color-scheme: dark) {
+  html:not([data-theme="light"]) {
+    --body-bg: #1a1a1a;
+    --body-text: #e0e0e0;
+    --link-color: #6ab0f5;
+    --tab-link-color: #6ab0f5;
+    --tab-active-color: #e0e0e0;
+    --control-bg: #2a2a2a;
+    --control-text: #e0e0e0;
+    --control-border: #555;
+    --button-bg: #2a2a2a;
+    --button-text: #e0e0e0;
+    --button-border: #555;
+    --button-hover-bg: #3a3a3a;
+    --button-hover-border: #555;
+    --surface-hover-bg: #3a3a3a;
+    --option-hover-text: #fff;
+    --editor-text: #e0e0e0;
+    --editor-bg: #2a2a2a;
+  }
 }
 
 textarea {
-    font-family: 'Consolas', 'Yu Gothic', 'Courier New';
-    height: 100%;
-    width: 100%;
-    box-sizing: border-box;
-    tab-size: 4;
-    letter-spacing: 0.02em;
-    text-size-adjust: none;
+  font-family: "Consolas", "Yu Gothic", "Courier New";
+  height: 100%;
+  width: 100%;
+  box-sizing: border-box;
+  tab-size: 4;
+  letter-spacing: 0.02em;
+  text-size-adjust: none;
+}
+
+textarea:not(.editor--highlighted) {
+  background-color: var(--control-bg);
+  color: var(--control-text);
+  border: 1px solid var(--control-border);
+}
+
+.editor-wrap {
+  position: relative;
+  flex-grow: 1;
+  min-height: 400px;
+  min-width: 400px;
+  resize: both;
+  overflow: hidden;
+}
+
+.editor-wrap > textarea,
+.container.editor-wrap > textarea {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 1;
+  margin: 0;
+  resize: none;
+  overflow: auto;
+}
+
+.editor-wrap > .highlight-layer,
+.container.editor-wrap > .highlight-layer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 0;
+}
+
+textarea.editor--highlighted {
+  background: transparent;
+  color: transparent;
+  -webkit-text-fill-color: transparent;
+  caret-color: var(--editor-text);
+  border: 1px solid var(--control-border);
+}
+
+.highlight-layer {
+  overflow: hidden;
+  margin: 0;
+  padding: 0;
+  pointer-events: none;
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  box-sizing: border-box;
+  border: 1px solid transparent;
+  color: var(--editor-text);
+  background-color: var(--editor-bg);
+  font-family: "Consolas", "Yu Gothic", "Courier New";
+  tab-size: 4;
+  letter-spacing: 0.02em;
+  text-size-adjust: none;
+}
+
+.highlight-layer span {
+  font: inherit;
+  letter-spacing: inherit;
+  line-height: inherit;
+}
+
+.hl-comment-semicolon {
+  color: var(--comment-semicolon);
+}
+.hl-comment-slash {
+  color: var(--comment-slash);
+}
+.hl-comment-percent {
+  color: var(--comment-percent);
+}
+.hl-comment-header {
+  color: var(--comment-header);
+}
+
+.hl-box-label {
+  color: var(--box-label);
+}
+.hl-box-number {
+  color: var(--box-number);
+  font-weight: var(--box-number-weight);
+}
+.hl-box-symbol {
+  color: var(--box-symbol);
+  font-weight: var(--box-symbol-weight);
+}
+.hl-box-letter {
+  color: var(--box-letter);
+}
+.hl-box-bracket {
+  color: var(--box-bracket);
+}
+.hl-box-bracket-inner.hl-box-number {
+  color: var(--box-number);
+  font-weight: var(--box-number-weight);
+}
+.hl-box-bracket-inner.hl-box-symbol {
+  color: var(--box-symbol);
+  font-weight: var(--box-symbol-weight);
+}
+.hl-box-bracket-inner.hl-box-letter {
+  color: var(--box-letter);
+}
+.hl-box-bold {
+  font-weight: bold;
 }
 
 #output {
-    min-height: 400px;
-    min-width: 400px;
+  min-height: 400px;
+  min-width: 400px;
 }
 
 #main {
-    min-height: 400px;
-    min-width: 400px;
+  min-height: 400px;
+  min-width: 400px;
 }
 
 #secondary {
-    min-height: 400px;
-    min-width: 400px;
+  min-height: 400px;
+  min-width: 400px;
 }
 
 .grow {
-    flex-grow: 1;
+  flex-grow: 1;
 }
 
 .row {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    align-items: stretch;
-    flex-wrap: wrap;
-    gap: 5px;
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: stretch;
+  flex-wrap: wrap;
+  gap: 5px;
 }
 
 .column {
-    flex-basis: 0;
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    align-items: stretch;
-    gap: 5px;
+  flex-basis: 0;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: stretch;
+  gap: 5px;
 }
 
 .left {
-    flex-basis: 0;
-    flex-shrink: 1;
+  flex-basis: 0;
+  flex-shrink: 1;
 }
 
 .middle {
-    flex-basis: 0;
-    flex-shrink: 1;
+  flex-basis: 0;
+  flex-shrink: 1;
 }
 
 .right {
-    flex-basis: 0;
-    flex-shrink: 1;
+  flex-basis: 0;
+  flex-shrink: 1;
 }
 
 /* ===== Tabs ===== */
 
-  .tablinks {
-    cursor: pointer;
-    color: blue;
-    text-decoration: underline;
-  }
-  
-  .tablinks-active {
-    cursor: default;
-    color: black;
-    text-decoration: none;
-  }
+.tablinks {
+  cursor: pointer;
+  color: var(--tab-link-color);
+  text-decoration: underline;
+}
 
-  .tabcontent {
-    display: none;
-  }
+.tablinks-active {
+  cursor: default;
+  color: var(--tab-active-color);
+  text-decoration: none;
+}
+
+.tabcontent {
+  display: none;
+}
 
 /* ===== Tom Select ===== */
 
 .ts-wrapper {
-    align-self: center;
+  align-self: center;
+}
+
+.ts-control,
+.ts-control input,
+.ts-dropdown,
+.ts-dropdown .option {
+  font-family: inherit !important;
+  font-size: var(--control-font-size) !important;
+  line-height: var(--control-line-height) !important;
 }
 
 .ts-control {
-    min-height: unset !important;
-    padding: 1px 6px !important;
-    flex-wrap: nowrap !important;
+  padding: var(--select-padding-y) var(--select-padding-x) !important;
+  min-height: calc(var(--control-line-height) + 2 * var(--select-padding-y)) !important;
+  flex-wrap: nowrap !important;
+  box-sizing: border-box !important;
+  border-radius: var(--select-border-radius) !important;
+  background-color: var(--control-bg) !important;
+  color: var(--control-text) !important;
+  border-color: var(--control-border) !important;
+}
+
+.ts-wrapper.focus .ts-control {
+  background-color: var(--control-bg) !important;
+  color: var(--control-text) !important;
+  border-color: var(--control-border) !important;
+}
+
+.ts-control input {
+  background-color: transparent !important;
+  color: var(--control-text) !important;
+  min-height: var(--control-line-height) !important;
+}
+
+.ts-dropdown {
+  background-color: var(--control-bg) !important;
+  color: var(--control-text) !important;
+  border-color: var(--control-border) !important;
+  border-radius: var(--select-border-radius) !important;
+}
+
+.ts-dropdown .create,
+.ts-dropdown .no-results,
+.ts-dropdown .optgroup-header,
+.ts-dropdown .option {
+  padding: var(--select-padding-y) var(--select-padding-x) !important;
+}
+
+.ts-dropdown .option:hover,
+.ts-dropdown .option.active {
+  background-color: var(--surface-hover-bg) !important;
+  color: var(--option-hover-text) !important;
 }
 
 .ts-dropdown .ts-dropdown-content {
-    max-height: 400px;
+  max-height: 400px;
 }
 
 /* ===== Other scripts ===== */
 
 #enter {
-    min-width: 75px;
-    padding: 10px 0px;
-}
-
-#theme-toggle {
-    min-width: unset;
-    padding: 2px 10px;
-    cursor: pointer;
-}
-
-/* ===== Dark mode ===== */
-
-@media (prefers-color-scheme: dark) {
-    html:not([data-theme="light"]) body {
-        background-color: #1a1a1a;
-        color: #e0e0e0;
-    }
-    html:not([data-theme="light"]) a {
-        color: #6ab0f5;
-    }
-    html:not([data-theme="light"]) .tablinks {
-        color: #6ab0f5;
-    }
-    html:not([data-theme="light"]) .tablinks-active {
-        color: #e0e0e0;
-    }
-    html:not([data-theme="light"]) select,
-    html:not([data-theme="light"]) button,
-    html:not([data-theme="light"]) textarea,
-    html:not([data-theme="light"]) .ts-control,
-    html:not([data-theme="light"]) .ts-wrapper.focus .ts-control,
-    html:not([data-theme="light"]) .ts-control input,
-    html:not([data-theme="light"]) .ts-dropdown {
-        background-color: #2a2a2a;
-        color: #e0e0e0;
-        border-color: #555;
-    }
-    html:not([data-theme="light"]) button {
-        appearance: none;
-        border: 1px solid #555;
-        box-shadow: none;
-    }
-    html:not([data-theme="light"]) button:hover {
-        background-color: #3a3a3a;
-    }
-    html:not([data-theme="light"]) .ts-dropdown .option:hover,
-    html:not([data-theme="light"]) .ts-dropdown .option.active {
-        background-color: #3a3a3a;
-        color: #ffffff;
-    }
-}
-
-html[data-theme="dark"] body {
-    background-color: #1a1a1a;
-    color: #e0e0e0;
-}
-html[data-theme="dark"] a {
-    color: #6ab0f5;
-}
-html[data-theme="dark"] .tablinks {
-    color: #6ab0f5;
-}
-html[data-theme="dark"] .tablinks-active {
-    color: #e0e0e0;
-}
-html[data-theme="dark"] select,
-html[data-theme="dark"] button,
-html[data-theme="dark"] textarea,
-html[data-theme="dark"] .ts-control,
-html[data-theme="dark"] .ts-wrapper.focus .ts-control,
-html[data-theme="dark"] .ts-control input,
-html[data-theme="dark"] .ts-dropdown {
-    background-color: #2a2a2a;
-    color: #e0e0e0;
-    border-color: #555;
-}
-html[data-theme="dark"] button {
-    appearance: none;
-    border: 1px solid #555;
-    box-shadow: none;
-}
-html[data-theme="dark"] button:hover {
-    background-color: #3a3a3a;
-}
-html[data-theme="dark"] .ts-dropdown .option:hover,
-html[data-theme="dark"] .ts-dropdown .option.active {
-    background-color: #3a3a3a;
-    color: #ffffff;
+  min-width: 75px;
+  padding: 10px 0;
 }


### PR DESCRIPTION
## Video comparison 


https://github.com/user-attachments/assets/4a4958ea-8b6d-448c-a753-c459207d7bc0


### Example for comparing lower case L vs number 1

<img width="494" height="260" alt="quickCheckBetweenLand1" src="https://github.com/user-attachments/assets/d3754cff-a3d0-4aef-a1a4-05572f366bef" />




## Why these changes

The generator was functional but hard to customize and visually inconsistent:

- Long ACE scripts are dense; comments and box-name output were plain monochrome text.
- Autocomplete only matched **prefixes** (`pik` → Pikachu), so partial or underscore-style names (`kachu`, `mr mime`) failed.
- Highlight overlay work introduced alignment, click-handling.

These changes keep the existing `@input:` tag model and data loading from EmeraldACE_web, but make the editor feel closer to a small IDE.

---

## New features

### Options menu (`options.js`, `options.css`)

Replaces the **Theme** button with an **Options** modal, persisted in `localStorage` under `acegen-options`.

| Section | What it does |
|--------|----------------|
| **Theme** | System / Light / Dark (`data-theme` on `<html>`, with `prefers-color-scheme` for system) |
| **Default options (this page)** | Per-game-page defaults for language and game (Emerald / FRLG / RS). URL `?lang=` / `?game=` still wins over saved defaults |
| **Comment colors** | Enable/disable comment highlighting; customize colors for `;`, `//`, `%%`, and `@@` per light/dark palette |

Settings migration: older flat color keys in storage are merged into the new light/dark palette structure.

### Syntax highlighting (`highlight.js`)

Non-destructive overlay approach (textarea text stays plain; a `div.highlight-layer` sits behind it):

- **Main editor (`#main`)** and **exit codes (`#secondary`)**: ACE comment tokens (`;`, `//`, `%%`, `@@`) colored from options.
- **Output (`#output`)**: Box name lines parsed and styled (`Box`, digits, punctuation, bracket contents).

Editors use `.editor-wrap` containers with synchronized font metrics (`copyTextareaStyles`), scroll, and `ResizeObserver` so visible text matches caret position. Highlighted textareas use transparent text + visible caret; the layer carries background and colors.

### Fuzzy search (`fuzzysearch.js`)

Shared scorer for:

1. **Script dropdown** (Tom Select custom `score`)
2. **Item/species/move/location autocomplete** (`autocomplete.js`)

Ranking supports exact ID (`25` → species #25), prefix, substring, underscore-as-space (`mr mime` → `Mr._Mime`), compact/subsequence matching, and multi-word prefixes. Replaces the old `startsWith` + numeric ID filter only.

Empty search returns score `1` for Tom Select so all scripts show when the dropdown opens (score `0` hid every option).

### Autocomplete keyboard navigation changes (`autocomplete.js`)

When the suggestion list is open:

- **Shift+Tab**: previous item, wraps to last when on first or nothing selected
